### PR TITLE
Implement MarshalJSON to output non-base64 encoded []byte

### DIFF
--- a/json.go
+++ b/json.go
@@ -36,6 +36,11 @@ func (j *JSON) Scan(value interface{}) error {
 	return err
 }
 
+// MarshalJSON to output non base64 encoded byte
+func (j *JSON) MarshalJSON() ([]byte, error) {
+	return json.RawMessage(*j).MarshalJSON()
+}
+
 // GormDataType gorm common data type
 func (JSON) GormDataType() string {
 	return "json"

--- a/json.go
+++ b/json.go
@@ -36,7 +36,7 @@ func (j *JSON) Scan(value interface{}) error {
 	return err
 }
 
-// MarshalJSON to output non base64 encoded byte
+// MarshalJSON to output non base64 encoded []byte
 func (j *JSON) MarshalJSON() ([]byte, error) {
 	return json.RawMessage(*j).MarshalJSON()
 }

--- a/json_test.go
+++ b/json_test.go
@@ -2,6 +2,7 @@ package datatypes_test
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -30,9 +31,11 @@ func TestJSON(t *testing.T) {
 		t.Errorf("failed to migrate, got error: %v", err)
 	}
 
+	user1Attrs := `{"age":18,"name":"json-1","orgs":{"orga":"orga"},"tags":["tag1","tag2"]}`
+
 	users := []UserWithJSON{{
 		Name:       "json-1",
-		Attributes: datatypes.JSON([]byte(`{"name": "json-1", "age": 18, "tags": ["tag1", "tag2"], "orgs": {"orga": "orga"}}`)),
+		Attributes: datatypes.JSON([]byte(user1Attrs)),
 	}, {
 		Name:       "json-2",
 		Attributes: datatypes.JSON([]byte(`{"name": "json-2", "age": 28, "tags": ["tag1", "tag3"], "role": "admin", "orgs": {"orgb": "orgb"}}`)),
@@ -53,4 +56,11 @@ func TestJSON(t *testing.T) {
 		t.Fatalf("failed to find user with json key, got error %v", err)
 	}
 	AssertEqual(t, result2.Name, users[0].Name)
+
+	// attributes should not marshal to base64 encoded []byte
+	result2Attrs, err := json.Marshal(&result2.Attributes)
+	if err != nil {
+		t.Fatalf("failed to marshal result2.Attributes, got error %v", err)
+	}
+	AssertEqual(t, string(result2Attrs), user1Attrs)
 }

--- a/json_test.go
+++ b/json_test.go
@@ -31,6 +31,8 @@ func TestJSON(t *testing.T) {
 		t.Errorf("failed to migrate, got error: %v", err)
 	}
 
+	// Go's json marshaler removes whitespace & orders keys alphabetically
+	// use to compare against marshaled []byte of datatypes.JSON
 	user1Attrs := `{"age":18,"name":"json-1","orgs":{"orga":"orga"},"tags":["tag1","tag2"]}`
 
 	users := []UserWithJSON{{


### PR DESCRIPTION
This PR is to MarshalJSON the datatypes.JSON type w/out base64 encoded []byte.  For example when retrieving database content w/ gorm, and serving a http json response.

more info:  https://groups.google.com/forum/#!topic/Golang-Nuts/38ShOlhxAYY

Before:
```json
{
  "Name": "json-1",
  "Attributes": "eyJhZ2UiOiAxOCwgIm5hbWUiOiAianNvbi0xIiwgIm9yZ3MiOiB7Im9yZ2EiOiAib3JnYSJ9LCAidGFncyI6IFsidGFnMSIsICJ0YWcyIl19"
}
```

After:
```json
{
  "Name": "json-1",
  "Attributes": {
    "age": 18,
    "name": "json-1",
    "orgs": {
      "orga": "orga"
    },
    "tags": [
      "tag1",
      "tag2"
    ]
  }
}
```