### PR TITLE
Support UnmarshalJSON of datastypes.JSON

### DIFF
--- a/json.go
+++ b/json.go
@@ -41,6 +41,14 @@ func (j JSON) MarshalJSON() ([]byte, error) {
 	return json.RawMessage(j).MarshalJSON()
 }
 
+// UnmarshalJSON to deserialize []byte
+func (j *JSON) UnmarshalJSON(b []byte) error {
+	result := json.RawMessage{}
+	err := result.UnmarshalJSON(b)
+	*j = JSON(result)
+	return err
+}
+
 // GormDataType gorm common data type
 func (JSON) GormDataType() string {
 	return "json"

--- a/json_test.go
+++ b/json_test.go
@@ -65,4 +65,12 @@ func TestJSON(t *testing.T) {
 		t.Fatalf("failed to marshal result2.Attributes, got error %v", err)
 	}
 	AssertEqual(t, string(result2Attrs), user1Attrs)
+
+	// []byte should unmarshal into type datatypes.JSON
+	var j datatypes.JSON
+	if err := json.Unmarshal([]byte(user1Attrs), &j); err != nil {
+		t.Fatalf("failed to unmarshal user1Attrs, got error %v", err)
+	}
+
+	AssertEqual(t, string(j), user1Attrs)
 }


### PR DESCRIPTION
This PR is to allow unmarshaling of datatypes.JSON for example when unmarshaling a `UserWithJSON{}` from a request body `{"name": "json-1", "attributes": {"age":18,"name":"json-1","orgs":{"orga":"orga"},"tags":["tag1","tag2"]}}`.

Before:
```
cannot unmarshal object into Go value of type datatypes.JSON
```

After:
```
{
  "name": "json-1",
  "attributes": {
    "age": 18,
    "name": "json-1",
    "orgs": {
      "orga": "orga"
    },
    "tags": [
      "tag1",
      "tag2"
    ]
  }
}
```