### PR TITLE
Added contains function for json array

### DIFF
--- a/json.go
+++ b/json.go
@@ -123,10 +123,14 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 				}
 
 			case jsonQuery.contains:
-				if len(jsonQuery.keys) > 0 && len(jsonQuery.containsValues) > 0 {
+				if len(jsonQuery.containsValues) > 0 {
 					builder.WriteString(fmt.Sprintf("JSON_CONTAINS(%s, '[", stmt.Quote(jsonQuery.column)))
 					stmt.AddVar(builder, jsonQuery.containsValues...)
-					builder.WriteString(fmt.Sprintf("]', '$.%s')", strings.Join(jsonQuery.keys, ".")))
+					keys := ""
+					for _, k := range jsonQuery.keys {
+						keys += "." + k
+					}
+					builder.WriteString(fmt.Sprintf("]', '$%s')", keys))
 				}
 			}
 		case "postgres":
@@ -145,7 +149,7 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 				}
 			case jsonQuery.contains:
 				fmt.Println(jsonQuery.keys)
-				if len(jsonQuery.keys) > 0 && len(jsonQuery.containsValues) > 0 {
+				if len(jsonQuery.containsValues) > 0 {
 					stmt.WriteQuoted(jsonQuery.column)
 					stmt.WriteString("::jsonb")
 					for _, key := range jsonQuery.keys {

--- a/json.go
+++ b/json.go
@@ -69,13 +69,13 @@ func (JSON) GormDBDataType(db *gorm.DB, field *schema.Field) string {
 
 // JSONQueryExpression json query expression, implements clause.Expression interface to use as querier
 type JSONQueryExpression struct {
-	column          string
-	keys            []string
-	hasKeys         bool
-	equals          bool
-	contains        bool
-	equalsValue     interface{}
-	countainsValues []interface{}
+	column         string
+	keys           []string
+	hasKeys        bool
+	equals         bool
+	contains       bool
+	equalsValue    interface{}
+	containsValues []interface{}
 }
 
 // JSONQuery query column as json
@@ -102,7 +102,7 @@ func (jsonQuery *JSONQueryExpression) Equals(value interface{}, keys ...string) 
 func (jsonQuery *JSONQueryExpression) Contains(values []interface{}, keys ...string) *JSONQueryExpression {
 	jsonQuery.keys = keys
 	jsonQuery.contains = true
-	jsonQuery.countainsValues = values
+	jsonQuery.containsValues = values
 	return jsonQuery
 }
 
@@ -123,9 +123,9 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 				}
 
 			case jsonQuery.contains:
-				if len(jsonQuery.keys) > 0 && len(jsonQuery.countainsValues) > 0 {
+				if len(jsonQuery.keys) > 0 && len(jsonQuery.containsValues) > 0 {
 					builder.WriteString(fmt.Sprintf("JSON_CONTAINS(%s, '[", stmt.Quote(jsonQuery.column)))
-					stmt.AddVar(builder, jsonQuery.countainsValues...)
+					stmt.AddVar(builder, jsonQuery.containsValues...)
 					builder.WriteString(fmt.Sprintf("]', '$.%s')", strings.Join(jsonQuery.keys, ".")))
 				}
 			}
@@ -145,7 +145,7 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 				}
 			case jsonQuery.contains:
 				fmt.Println(jsonQuery.keys)
-				if len(jsonQuery.keys) > 0 && len(jsonQuery.countainsValues) > 0 {
+				if len(jsonQuery.keys) > 0 && len(jsonQuery.containsValues) > 0 {
 					stmt.WriteQuoted(jsonQuery.column)
 					stmt.WriteString("::jsonb")
 					for _, key := range jsonQuery.keys {
@@ -154,7 +154,7 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 					}
 					stmt.WriteString(" ?| ")
 					stmt.WriteString("ARRAY[")
-					stmt.AddVar(builder, jsonQuery.countainsValues...)
+					stmt.AddVar(builder, jsonQuery.containsValues...)
 					stmt.WriteString("]")
 				}
 			case jsonQuery.equals:

--- a/json_test.go
+++ b/json_test.go
@@ -95,5 +95,16 @@ func TestJSON(t *testing.T) {
 			t.Fatalf("failed to find user with json value in array, got error %v", err)
 		}
 
+		result7 := UserWithJSON{
+			Name:       "json-3",
+			Attributes: datatypes.JSON([]byte(`["tag1"]`)),
+		}
+		if err := DB.Create(&result7).Error; err != nil {
+			t.Fatalf("failed create user %v", err)
+		}
+		if err := DB.First(&result7, datatypes.JSONQuery("attributes").Contains([]interface{}{"tag1", "tag2"})).Error; err != nil {
+			t.Fatalf("failed to find user with json value in array, got error %v", err)
+		}
+
 	}
 }

--- a/json_test.go
+++ b/json_test.go
@@ -87,8 +87,13 @@ func TestJSON(t *testing.T) {
 		}
 
 		var result5 UserWithJSON
-		if err := DB.First(&result5, datatypes.JSONQuery("attributes").Equals(19, "age")).Error; err != nil {
+		if err := DB.First(&result5, datatypes.JSONQuery("attributes").Equals(18, "age")).Error; err != nil {
 			t.Fatalf("failed to find user with json value, got error %v", err)
 		}
+		var result6 UserWithJSON
+		if err := DB.First(&result6, datatypes.JSONQuery("attributes").Contains([]interface{}{"tag1", "tag2"}, "tags")).Error; err != nil {
+			t.Fatalf("failed to find user with json value in array, got error %v", err)
+		}
+
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested (almost). for MySQL, I got an error, but can't understand where @jinzhu could you can help me?
```
TestJSON: json_test.go:95: failed to find user with json value in array, got error sql: expected 0 arguments, got 2
```

### What did this pull request do?

The added function `contains` for json arrays.
An example. Has table `test` in postgres:
```
gorm=# create table test(id int, attributes jsonb);
gorm=# insert into test(id, attributes) values (1, '{"tags":["tag1","tag2"]}');

gorm=# select * from test;
 id |         attributes         
----+----------------------------
  1 | {"tags": ["tag1", "tag2"]}
(1 row)

gorm=# select id from test where "attributes"::jsonb -> 'tags' ?| array['tag1'];
 id 
----
  1
(1 row)

```
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

[Table 9-41. Additional jsonb Operators](https://www.postgresql.org/docs/9.4/functions-json.html#FUNCTIONS-JSONB-OP-TABLE)

Operator | Right Operand Type | Description | Example
-- | -- | -- | --
?\| | text[] | Do any of these key/element strings exist? | '{"a":1, "b":2, "c":3}'::jsonb ?\| array['b', 'c']




<!-- Your use case -->
