### PR TITLE
[Break Changes] Fix json syntax error with pgx `PreferSimpleProtocol: true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ type UserWithJSON struct {
 
 DB.Create(&User{
 	Name:       "json-1",
-	Attributes: datatypes.JSON([]byte(`{"name": "jinzhu", "age": 18, "tags": ["tag1", "tag2"], "orgs": {"orga": "orga"}}`)),
+	Attributes: datatypes.JSON(`{"name": "jinzhu", "age": 18, "tags": ["tag1", "tag2"], "orgs": {"orga": "orga"}}`),
 }
 
 // Check JSON has keys

--- a/json.go
+++ b/json.go
@@ -13,14 +13,11 @@ import (
 )
 
 // JSON defiend JSON data type, need to implements driver.Valuer, sql.Scanner interface
-type JSON json.RawMessage
+type JSON string
 
 // Value return json value, implement driver.Valuer interface
 func (j JSON) Value() (driver.Value, error) {
-	if len(j) == 0 {
-		return nil, nil
-	}
-	return json.RawMessage(j).MarshalJSON()
+	return string(j), nil
 }
 
 // Scan scan value into Jsonb, implements sql.Scanner interface
@@ -30,28 +27,24 @@ func (j *JSON) Scan(value interface{}) error {
 		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
 	}
 
-	result := json.RawMessage{}
-	err := json.Unmarshal(bytes, &result)
-	*j = JSON(result)
-	return err
+	*j = JSON(bytes)
+	return nil
 }
 
 // MarshalJSON to output non base64 encoded []byte
 func (j JSON) MarshalJSON() ([]byte, error) {
-	return json.RawMessage(j).MarshalJSON()
+	return json.RawMessage([]byte(j)).MarshalJSON()
 }
 
 // UnmarshalJSON to deserialize []byte
 func (j *JSON) UnmarshalJSON(b []byte) error {
-	result := json.RawMessage{}
-	err := result.UnmarshalJSON(b)
-	*j = JSON(result)
-	return err
+	*j = JSON(string(b))
+	return nil
 }
 
 // GormDataType gorm common data type
 func (JSON) GormDataType() string {
-	return "json"
+	return "string"
 }
 
 // GormDBDataType gorm db data type

--- a/json_test.go
+++ b/json_test.go
@@ -1,7 +1,6 @@
 package datatypes_test
 
 import (
-	"database/sql/driver"
 	"encoding/json"
 	"testing"
 
@@ -10,7 +9,7 @@ import (
 	. "gorm.io/gorm/utils/tests"
 )
 
-var _ driver.Valuer = &datatypes.JSON{}
+// var _ driver.Valuer = &datatypes.JSON{}
 
 func TestJSON(t *testing.T) {
 	if SupportedDriver("sqlite", "mysql", "postgres") {
@@ -31,10 +30,10 @@ func TestJSON(t *testing.T) {
 
 		users := []UserWithJSON{{
 			Name:       "json-1",
-			Attributes: datatypes.JSON([]byte(user1Attrs)),
+			Attributes: datatypes.JSON(user1Attrs),
 		}, {
 			Name:       "json-2",
-			Attributes: datatypes.JSON([]byte(`{"name": "json-2", "age": 28, "tags": ["tag1", "tag3"], "role": "admin", "orgs": {"orgb": "orgb"}}`)),
+			Attributes: datatypes.JSON(`{"name": "json-2", "age": 28, "tags": ["tag1", "tag3"], "role": "admin", "orgs": {"orgb": "orgb"}}`),
 		}}
 
 		if err := DB.Create(&users).Error; err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -37,7 +37,10 @@ func OpenTestConnection() (db *gorm.DB, err error) {
 		if dbDSN == "" {
 			dbDSN = "user=gorm password=gorm dbname=gorm port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 		}
-		db, err = gorm.Open(postgres.Open(dbDSN), &gorm.Config{})
+		db, err = gorm.Open(postgres.New(postgres.Config{
+			DSN:                  dbDSN,
+			PreferSimpleProtocol: true,
+		}), &gorm.Config{})
 	case "sqlserver":
 		// CREATE LOGIN gorm WITH PASSWORD = 'LoremIpsum86';
 		// CREATE DATABASE gorm;


### PR DESCRIPTION
```
pgtype.JSON ERROR: invalid input syntax for type json (SQLSTATE 22P02)
```

By pgx author said:

- https://github.com/jackc/pgtype/issues/45#issuecomment-652383139 
- https://github.com/jackc/pgx/issues/409#issuecomment-381332515

Change base type to `string` can fix that issue.