### PR TITLE
support  json & gob encoding for Date

### DIFF
--- a/date.go
+++ b/date.go
@@ -24,3 +24,11 @@ func (date Date) Value() (driver.Value, error) {
 func (date Date) GormDataType() string {
 	return "date"
 }
+
+func (date Date) GobEncode() ([]byte, error) {
+	return time.Time(date).GobEncode()
+}
+
+func (date *Date) GobDecode(b []byte) error {
+	return (*time.Time)(date).GobDecode(b)
+}

--- a/date.go
+++ b/date.go
@@ -32,3 +32,11 @@ func (date Date) GobEncode() ([]byte, error) {
 func (date *Date) GobDecode(b []byte) error {
 	return (*time.Time)(date).GobDecode(b)
 }
+
+func (date Date) MarshalJSON() ([]byte, error) {
+	return time.Time(date).MarshalJSON()
+}
+
+func (date *Date) UnmarshalJSON(b []byte) error {
+	return (*time.Time)(date).UnmarshalJSON(b)
+}

--- a/date_test.go
+++ b/date_test.go
@@ -3,6 +3,7 @@ package datatypes_test
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -48,6 +49,21 @@ func TestGobEncoding(t *testing.T) {
 	dec := gob.NewDecoder(&buf)
 	var got datatypes.Date
 	if err := dec.Decode(&got); err != nil {
+		t.Fatalf("failed to decode to datatypes.Date: %v", err)
+	}
+
+	AssertEqual(t, date, got)
+}
+
+func TestJSONEncoding(t *testing.T) {
+	date := datatypes.Date(time.Now())
+	b, err := json.Marshal(date)
+	if err != nil {
+		t.Fatalf("failed to encode datatypes.Date: %v", err)
+	}
+
+	var got datatypes.Date
+	if err := json.Unmarshal(b, &got); err != nil {
 		t.Fatalf("failed to decode to datatypes.Date: %v", err)
 	}
 

--- a/date_test.go
+++ b/date_test.go
@@ -1,6 +1,8 @@
 package datatypes_test
 
 import (
+	"bytes"
+	"encoding/gob"
 	"testing"
 	"time"
 
@@ -33,4 +35,21 @@ func TestDate(t *testing.T) {
 	}
 
 	AssertEqual(t, result.Date, beginningOfDay)
+}
+
+func TestGobEncoding(t *testing.T) {
+	date := datatypes.Date(time.Now())
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(date); err != nil {
+		t.Fatalf("failed to encode datatypes.Date: %v", err)
+	}
+
+	dec := gob.NewDecoder(&buf)
+	var got datatypes.Date
+	if err := dec.Decode(&got); err != nil {
+		t.Fatalf("failed to decode to datatypes.Date: %v", err)
+	}
+
+	AssertEqual(t, date, got)
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Allow to encode/decode `Date` using encoding/gob and encoding/json

### User Case Description

Encode/decode struct that contains `datatypes.Date` fields
