### PR TITLE
Use date as time.Time itself is struct

### DIFF
--- a/date.go
+++ b/date.go
@@ -6,37 +6,26 @@ import (
 	"time"
 )
 
-type Date time.Time
+// Date defiend Date data type, need to implements driver.Valuer, sql.Scanner interface
+type Date struct {
+	time.Time
+}
 
+// Value return date value, implement driver.Valuer interface
+func (date Date) Value() (driver.Value, error) {
+	y, m, d := date.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, date.Location()), nil
+}
+
+// Scan scan value into time.Time, implements sql.Scanner interface
 func (date *Date) Scan(value interface{}) (err error) {
 	nullTime := &sql.NullTime{}
 	err = nullTime.Scan(value)
-	*date = Date(nullTime.Time)
+	*date = Date{nullTime.Time}
 	return
-}
-
-func (date Date) Value() (driver.Value, error) {
-	y, m, d := time.Time(date).Date()
-	return time.Date(y, m, d, 0, 0, 0, 0, time.Time(date).Location()), nil
 }
 
 // GormDataType gorm common data type
 func (date Date) GormDataType() string {
 	return "date"
-}
-
-func (date Date) GobEncode() ([]byte, error) {
-	return time.Time(date).GobEncode()
-}
-
-func (date *Date) GobDecode(b []byte) error {
-	return (*time.Time)(date).GobDecode(b)
-}
-
-func (date Date) MarshalJSON() ([]byte, error) {
-	return time.Time(date).MarshalJSON()
-}
-
-func (date *Date) UnmarshalJSON(b []byte) error {
-	return (*time.Time)(date).UnmarshalJSON(b)
 }

--- a/date_test.go
+++ b/date_test.go
@@ -27,11 +27,11 @@ func TestDate(t *testing.T) {
 	curTime := time.Now().UTC()
 	beginningOfDay := now.New(curTime).BeginningOfDay()
 
-	user := UserWithDate{Name: "jinzhu", Date: datatypes.Date(curTime)}
+	user := UserWithDate{Name: "jinzhu", Date: datatypes.Date{curTime}}
 	DB.Create(&user)
 
 	result := UserWithDate{}
-	if err := DB.First(&result, "name = ? AND date = ?", "jinzhu", datatypes.Date(curTime)).Error; err != nil {
+	if err := DB.First(&result, "name = ? AND date = ?", "jinzhu", datatypes.Date{curTime}).Error; err != nil {
 		t.Fatalf("Failed to find record with date")
 	}
 
@@ -39,7 +39,7 @@ func TestDate(t *testing.T) {
 }
 
 func TestGobEncoding(t *testing.T) {
-	date := datatypes.Date(time.Now())
+	date := datatypes.Date{time.Now()}
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)
 	if err := enc.Encode(date); err != nil {
@@ -56,7 +56,7 @@ func TestGobEncoding(t *testing.T) {
 }
 
 func TestJSONEncoding(t *testing.T) {
-	date := datatypes.Date(time.Now())
+	date := datatypes.Date{time.Now()}
 	b, err := json.Marshal(date)
 	if err != nil {
 		t.Fatalf("failed to encode datatypes.Date: %v", err)

--- a/json.go
+++ b/json.go
@@ -98,7 +98,7 @@ func (jsonQuery *JSONQueryExpression) HasKey(keys ...string) *JSONQueryExpressio
 	return jsonQuery
 }
 
-// Keys returns clause.Expression
+// Equals Keys returns clause.Expression
 func (jsonQuery *JSONQueryExpression) Equals(value interface{}, keys ...string) *JSONQueryExpression {
 	jsonQuery.keys = keys
 	jsonQuery.equals = true


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [ ] Non breaking API changes
- [x] Tested

### What did this pull request do?

such as json.RawMessage is alias of []byte. use data as struct wrapper time.Time struct fills better.


### User Case Description

<!-- Your use case -->
