### PR TITLE
Fix unmarshal error in JSON/JSONMap scan for null values

### DIFF
--- a/json.go
+++ b/json.go
@@ -26,6 +26,10 @@ func (j JSON) Value() (driver.Value, error) {
 
 // Scan scan value into Jsonb, implements sql.Scanner interface
 func (j *JSON) Scan(value interface{}) error {
+	if value == nil {
+		*j = JSON("null")
+		return nil
+	}
 	var bytes []byte
 	switch v := value.(type) {
 	case []byte:

--- a/json_map.go
+++ b/json_map.go
@@ -24,6 +24,10 @@ func (m JSONMap) Value() (driver.Value, error) {
 
 // Scan scan value into Jsonb, implements sql.Scanner interface
 func (m *JSONMap) Scan(val interface{}) error {
+	if val == nil {
+		*m = make(JSONMap)
+		return nil
+	}
 	var ba []byte
 	switch v := val.(type) {
 	case []byte:


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [] Tested

### What did this pull request do?

While fetching null value from the DB, Scan() throws an error like this: `2021/06/22 02:54:11 /Users/krishna.birla/Repos/rp-manager/pkg/store/sqlstore/sqlstore.go:89 sql: Scan error on column index 0, name "admins": Failed to unmarshal JSON value:<nil>`

### User Case Description

<!-- Your use case -->
For example, if your JSON or JSONMap field is `default:null`, it fails to Scan() it.