### PR TITLE
fix(json): JSON's value is a empty string when it's empty

### DIFF
--- a/json.go
+++ b/json.go
@@ -84,13 +84,19 @@ func (JSON) GormDBDataType(db *gorm.DB, field *schema.Field) string {
 }
 
 func (js JSON) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
+	if len(js) == 0 {
+		return gorm.Expr("NULL")
+	}
+
 	data, _ := js.MarshalJSON()
+
 	switch db.Dialector.Name() {
 	case "mysql":
 		if v, ok := db.Dialector.(*mysql.Dialector); ok && !strings.Contains(v.ServerVersion, "MariaDB") {
 			return gorm.Expr("CAST(? AS JSON)", string(data))
 		}
 	}
+
 	return gorm.Expr("?", string(data))
 }
 

--- a/json_map.go
+++ b/json_map.go
@@ -43,7 +43,7 @@ func (m *JSONMap) Scan(val interface{}) error {
 	}
 	t := map[string]interface{}{}
 	err := json.Unmarshal(ba, &t)
-	*m = JSONMap(t)
+	*m = t
 	return err
 }
 


### PR DESCRIPTION
when the filed's value is datatypes.JSON{}, it will be error when insert. Because the filed's value
is a empty string instead of NULL.

fix #99

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [] Do only one thing
- [] Non breaking API changes
- [☑️] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
I think it a bug.
The table defined:
```
type User struct {
        Name string
        Email datatypes.JSON
}
```
Then i insert a value.
```
u := User {
    Name: "adsa",
    Email: datatypes.JSON{},
}
db.Create(&u)
```
The sql will be generated:
```
INSERT INTO `users` (`name`,`email`) VALUES ('adsa',CAST('' AS JSON))
```
and raise an error:
`
Error 3141: Invalid JSON text in argument 1 to function cast_as_json: "The document is empty." at position 0.
`

I think when `email` is a default value `datatypes.Json{}` or `nil`, the sql value should be `NULL` instead of `""`, the sql should be `CAST(NULL AS JSON))`  instead of `CAST('' AS JSON))`


<!-- Your use case -->
