### PR TITLE
Add a URL type support

### DIFF
--- a/url.go
+++ b/url.go
@@ -1,0 +1,66 @@
+package datatypes
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+type URL url.URL
+
+func (u URL) Value() (driver.Value, error) {
+	return u.String(), nil
+}
+
+func (u *URL) Scan(value interface{}) error {
+	var us string
+	switch v := value.(type) {
+	case []byte:
+		us = string(v)
+	case string:
+		us = v
+	default:
+		return errors.New(fmt.Sprint("Failed to parse URL:", value))
+	}
+	uu, err := url.Parse(us)
+	if err != nil {
+		return err
+	}
+	*u = URL(*uu)
+	return nil
+}
+
+func (URL) GormDataType() string {
+	return "url"
+}
+
+func (URL) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	return "TEXT"
+}
+
+func (u *URL) String() string {
+	return (*url.URL)(u).String()
+}
+
+func (u URL) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.String())
+}
+
+func (u *URL) UnmarshalJSON(data []byte) error {
+	// ignore null
+	if string(data) == "null" {
+		return nil
+	}
+	uu, err := url.Parse(strings.Trim(string(data), `"'`))
+	if err != nil {
+		return err
+	}
+	*u = URL(*uu)
+	return nil
+}

--- a/url_test.go
+++ b/url_test.go
@@ -1,0 +1,92 @@
+package datatypes_test
+
+import (
+	"net/url"
+	"testing"
+
+	"gorm.io/datatypes"
+	. "gorm.io/gorm/utils/tests"
+)
+
+func TestURL(t *testing.T) {
+	type StructWithURL struct {
+		ID       uint
+		FileName string
+		Storage  datatypes.URL
+	}
+	_ = DB.Migrator().DropTable(&StructWithURL{})
+	if err := DB.Migrator().AutoMigrate(&StructWithURL{}); err != nil {
+		t.Fatalf("failed to migrate, got error: %v", err)
+	}
+	f1 := StructWithURL{
+		FileName: "FLocal1",
+		Storage: datatypes.URL{
+			Scheme: "file",
+			Path:   "/tmp/f1",
+		},
+	}
+	us := "sftp://user:pwd@127.0.0.1/f2?query=1#frag"
+	u2, _ := url.Parse(us)
+	f2 := StructWithURL{
+		FileName: "FRemote2",
+		Storage:  datatypes.URL(*u2),
+	}
+
+	uf1 := url.URL(f1.Storage)
+	uf2 := url.URL(f2.Storage)
+	DB.Create(&f1)
+	DB.Create(&f2)
+
+	result := StructWithURL{}
+	if err := DB.First(&result, "file_name = ? AND storage = ?", "FLocal1",
+		datatypes.URL{
+			Scheme: "file",
+			Path:   "/tmp/f1",
+		}).Error; err != nil {
+		t.Fatalf("failed to find record with url, got error: %v", err)
+	}
+	AssertEqual(t, uf1.String(), result.Storage.String())
+
+	result = StructWithURL{}
+	if err := DB.First(&result, "file_name = ? AND storage = ?", "FRemote2",
+		datatypes.URL{
+			Scheme:      "sftp",
+			User:        url.UserPassword("user", "pwd"),
+			Host:        "127.0.0.1",
+			Path:        "/f2",
+			RawPath:     "should not affects",
+			RawQuery:    "query=1",
+			Fragment:    "frag",
+			RawFragment: "should not affects",
+		}).Error; err != nil {
+		t.Fatalf("failed to find record with url, got error: %v", err)
+	}
+	AssertEqual(t, u2.String(), uf2.String())
+	AssertEqual(t, uf2.String(), result.Storage.String())
+	AssertEqual(t, us, result.Storage.String())
+
+	result = StructWithURL{}
+	if err := DB.First(&result, "file_name = ? AND storage = ?", "FRemote2",
+		datatypes.URL{
+			Scheme:   "sftp",
+			Opaque:   "//user:pwd@127.0.0.1/f2",
+			RawQuery: "query=1",
+			Fragment: "frag",
+		}).Error; err != nil {
+		t.Fatalf("failed to find record with url, got error: %v", err)
+	}
+	AssertEqual(t, us, result.Storage.String())
+
+	result = StructWithURL{}
+	if err := DB.First(&result, "file_name = ? AND storage = ?", "FRemote2",
+		datatypes.URL{
+			Scheme:   "sftp",
+			User:     url.User("user"),
+			Host:     "127.0.0.1",
+			Path:     "/f2",
+			RawQuery: "query=1",
+			Fragment: "frag",
+		}).Error; err == nil {
+		t.Fatalf("record couldn't have been identical: %v vs %v", result.Storage, us)
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
- It's boring to repeatedly parse/translate url between db storage and a struct
- So I made a simple valuer/scanner and hope it could be contributed

### User Case Description

<!-- Your use case -->
A proxied resource provider:
```golang
type Resource struct {
  ID       uint
  Name     string
  Storage  datatypes.URL
}

if db.Where("name = ?", "NameOfResource").First(&res).Error != nil{
  switch res.Storage.Scheme {
  case "file":
    f, _ := os.Open(res.Storage.Path)
    s, _ := f.Stat()
    gin_context.DataFromReader(200,  s.Size(), 'application/octet-stream', f, header)
  case "http":
    resp := http.Get(res.Storage.String())
    gin_context.DataFromReader(200, resp.ContentLength, 'application/octet-stream', resp.Body, header)
  }
}
```
