### PR TITLE
skip copying when scanning datatypes.JSON

### DIFF
--- a/json.go
+++ b/json.go
@@ -42,10 +42,9 @@ func (j *JSON) Scan(value interface{}) error {
 		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
 	}
 
-	result := json.RawMessage{}
-	err := json.Unmarshal(bytes, &result)
+	result := json.RawMessage(bytes)
 	*j = JSON(result)
-	return err
+	return nil
 }
 
 // MarshalJSON to output non base64 encoded []byte
@@ -193,7 +192,6 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 		}
 	}
 }
-
 
 const prefix = "$."
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

`Scan` to `datatypes.JSON` [makes a copy](https://github.com/golang/go/blob/a131fd1313e0056ad094d234c67648409d081b8c/src/encoding/json/stream.go#L275), this shouldn't be necessary

### User Case Description

<!-- Your use case -->
model has some big JSON in postgres jsonb, it wastes time and memory to copy