### PR TITLE
fix: json scan can not use in place value

### DIFF
--- a/json.go
+++ b/json.go
@@ -35,7 +35,10 @@ func (j *JSON) Scan(value interface{}) error {
 	var bytes []byte
 	switch v := value.(type) {
 	case []byte:
-		bytes = v
+		if len(v) > 0 {
+			bytes = make([]byte, len(v))
+			copy(bytes, v)
+		}
 	case string:
 		bytes = []byte(v)
 	default:


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
close https://github.com/go-gorm/datatypes/issues/136

We can not use in-place value after this commit https://github.com/go-gorm/datatypes/commit/c244d2875ae06d92f7f0765444f297b8aced0a08

https://github.com/golang/go/blob/master/src/database/sql/sql.go#L3008
https://github.com/golang/go/blob/master/src/database/sql/sql.go#L3286

### User Case Description

<!-- Your use case -->


