### PR TITLE
add JSONType[T] for json data type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,31 @@
 module gorm.io/datatypes
 
-go 1.14
+go 1.19
 
 require (
-	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/jinzhu/now v1.1.5
-	github.com/mattn/go-sqlite3 v1.14.12 // indirect
-	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	gorm.io/driver/mysql v1.3.2
 	gorm.io/driver/postgres v1.3.4
 	gorm.io/driver/sqlite v1.3.1
 	gorm.io/driver/sqlserver v1.3.1
 	gorm.io/gorm v1.23.6
+)
+
+require (
+	github.com/denisenkom/go-mssqldb v0.12.0 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
+	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
+	github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188 // indirect
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/pgconn v1.11.0 // indirect
+	github.com/jackc/pgio v1.0.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/pgtype v1.10.0 // indirect
+	github.com/jackc/pgx/v4 v4.15.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.12 // indirect
+	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
+	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,6 @@ github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2V
 github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188 h1:+eHOFJl1BaXrQxKX+T06f78590z4qA2ZzBTqahsKSE4=
 github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188/go.mod h1:vXjM/+wXQnTPR4KqTKDgJukSZ6amVRtWMPEjE6sQoK8=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -49,7 +48,6 @@ github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65 h1:DadwsjnMwFjfWc9y5W
 github.com/jackc/pgmock v0.0.0-20210724152146-4ad1a8207f65/go.mod h1:5R2h2EEX+qri8jOWMbJCtaPWkrrNc7OHwsp2TCqp7ak=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
-github.com/jackc/pgproto3 v1.1.0 h1:FYYE4yRw+AgI8wXIinMlNjBbp/UitDJwfj5LqqewP1A=
 github.com/jackc/pgproto3 v1.1.0/go.mod h1:eR5FA3leWg7p9aeAqi37XOTgTIbkABlvcPB3E5rlc78=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190420180111-c116219b62db/go.mod h1:bhq50y+xrl9n5mRYyCBFKkpRVTLYJVWeCc+mEAI3yXA=
 github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod h1:uH0AWtUmuShn0bcesswc4aBTWGvw0cAxIJp+6OB//Wg=
@@ -85,11 +83,9 @@ github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -163,7 +159,6 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -201,7 +196,6 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=

--- a/json_type.go
+++ b/json_type.go
@@ -1,0 +1,80 @@
+package datatypes
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/schema"
+)
+
+// JSONType give a generic data type for json encoded data.
+type JSONType[T any] struct {
+	Data T
+}
+
+// Value return json value, implement driver.Valuer interface
+func (j JSONType[T]) Value() (driver.Value, error) {
+	return json.Marshal(j.Data)
+}
+
+// Scan scan value into JSONType[T], implements sql.Scanner interface
+func (j *JSONType[T]) Scan(value interface{}) error {
+	var bytes []byte
+	switch v := value.(type) {
+	case []byte:
+		bytes = v
+	case string:
+		bytes = []byte(v)
+	default:
+		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
+	}
+	return json.Unmarshal(bytes, &j.Data)
+}
+
+// MarshalJSON to output non base64 encoded []byte
+func (j JSONType[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(j.Data)
+}
+
+// UnmarshalJSON to deserialize []byte
+func (j *JSONType[T]) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, &j.Data)
+}
+
+// GormDataType gorm common data type
+func (JSONType[T]) GormDataType() string {
+	return "json"
+}
+
+// GormDBDataType gorm db data type
+func (JSONType[T]) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	switch db.Dialector.Name() {
+	case "sqlite":
+		return "JSON"
+	case "mysql":
+		return "JSON"
+	case "postgres":
+		return "JSONB"
+	}
+	return ""
+}
+
+func (js JSONType[T]) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
+	data, _ := js.MarshalJSON()
+
+	switch db.Dialector.Name() {
+	case "mysql":
+		if v, ok := db.Dialector.(*mysql.Dialector); ok && !strings.Contains(v.ServerVersion, "MariaDB") {
+			return gorm.Expr("CAST(? AS JSON)", string(data))
+		}
+	}
+
+	return gorm.Expr("?", string(data))
+}

--- a/json_type_test.go
+++ b/json_type_test.go
@@ -1,0 +1,94 @@
+package datatypes_test
+
+import (
+	"database/sql/driver"
+	"testing"
+
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	. "gorm.io/gorm/utils/tests"
+)
+
+var _ driver.Valuer = &datatypes.JSONType[[]int]{}
+
+func newJSONType[T any](b []byte) datatypes.JSONType[T] {
+	var t datatypes.JSONType[T]
+	_ = t.UnmarshalJSON(b)
+	return t
+}
+
+func TestJSONType(t *testing.T) {
+	if SupportedDriver("sqlite", "mysql", "postgres") {
+		type Attribute struct {
+			Sex   int
+			Age   int
+			Orgs  map[string]string
+			Tags  []string
+			Admin bool
+			Role  string
+		}
+		type UserWithJSON struct {
+			gorm.Model
+			Name       string
+			Attributes datatypes.JSONType[Attribute]
+		}
+
+		DB.Migrator().DropTable(&UserWithJSON{})
+		if err := DB.Migrator().AutoMigrate(&UserWithJSON{}); err != nil {
+			t.Errorf("failed to migrate, got error: %v", err)
+		}
+
+		// Go's json marshaler removes whitespace & orders keys alphabetically
+		// use to compare against marshaled []byte of datatypes.JSON
+		user1Attrs := `{"age":18,"name":"json-1","orgs":{"orga":"orga"},"tags":["tag1","tag2"],"admin":true}`
+
+		users := []UserWithJSON{{
+			Name:       "json-1",
+			Attributes: newJSONType[Attribute]([]byte(user1Attrs)),
+		}, {
+			Name:       "json-2",
+			Attributes: newJSONType[Attribute]([]byte(`{"name": "json-2", "age": 28, "tags": ["tag1", "tag3"], "role": "admin", "orgs": {"orgb": "orgb"}}`)),
+		}, {
+			Name:       "json-3",
+			Attributes: newJSONType[Attribute]([]byte(`{"tags": ["tag1","tag2","tag3"]`)),
+		}}
+
+		if err := DB.Create(&users).Error; err != nil {
+			t.Errorf("Failed to create users %v", err)
+		}
+
+		var result UserWithJSON
+		if err := DB.First(&result, users[1].ID).Error; err != nil {
+			t.Fatalf("failed to find user with json key, got error %v", err)
+		}
+		AssertEqual(t, result.Name, users[1].Name)
+		AssertEqual(t, result.Attributes.Data.Age, users[1].Attributes.Data.Age)
+		AssertEqual(t, result.Attributes.Data.Admin, users[1].Attributes.Data.Admin)
+		AssertEqual(t, len(result.Attributes.Data.Orgs), len(users[1].Attributes.Data.Orgs))
+
+		// FirstOrCreate
+		jsonMap := UserWithJSON{
+			Attributes: newJSONType[Attribute]([]byte(`{"age":19,"name":"json-1","orgs":{"orga":"orga"},"tags":["tag1","tag2"]}`)),
+		}
+		if err := DB.Where(&UserWithJSON{Name: "json-1"}).Assign(jsonMap).FirstOrCreate(&UserWithJSON{}).Error; err != nil {
+			t.Errorf("failed to run FirstOrCreate")
+		}
+
+		// Update
+		jsonMap = UserWithJSON{
+			Attributes: datatypes.JSONType[Attribute]{
+				Data: Attribute{
+					Age:  18,
+					Sex:  1,
+					Orgs: map[string]string{"orga": "orga"},
+					Tags: []string{"tag1", "tag2", "tag3"},
+				},
+			},
+		}
+		var result3 UserWithJSON
+		result3.ID = 1
+		if err := DB.Model(&result3).Updates(jsonMap).Error; err != nil {
+			t.Errorf("failed to run FirstOrCreate")
+		}
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->
 as show in the test file,

JSONType can provide a generic for the column with json type.

do not need user to define Scan or Value on there custom field with json type.

```go
		type Attribute struct {
			Sex   int
			Age   int
			Orgs  map[string]string
			Tags  []string
			Admin bool
			Role  string
		}
		type UserWithJSON struct {
			gorm.Model
			Name       string
			Attributes datatypes.JSONType[Attribute]
		}

```


### User Case Description

```go
// the business need field
		type Attribute struct {
			Sex   int
			Age   int
			Orgs  map[string]string
			Tags  []string
			Admin bool
			Role  string
		}


// a user model
		type UserWithJSON struct {
			gorm.Model
			Name       string
			Attributes datatypes.JSONType[Attribute]
		}


		var user = UserWithJSON{
			Attributes: datatypes.JSONType[Attribute]{
				Data: Attribute{
					Age:  18,
					Sex:  1,
					Orgs: map[string]string{"orga": "orga"},
					Tags: []string{"tag1", "tag2", "tag3"},
				},
			},
		}
                if err :=DB.Model(&user).Create(&user).Error; err != nil {
                       return err
		}


```
