### PR TITLE
Added JSON postgresql extract

### DIFF
--- a/json.go
+++ b/json.go
@@ -178,6 +178,10 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 			}
 		case "postgres":
 			switch {
+			case jsonQuery.extract:
+				builder.WriteString(fmt.Sprintf("json_extract_path_text(%v::json,", stmt.Quote(jsonQuery.column)))
+				stmt.AddVar(builder, jsonQuery.path)
+				builder.WriteByte(')')
 			case jsonQuery.hasKeys:
 				if len(jsonQuery.keys) > 0 {
 					stmt.WriteQuoted(jsonQuery.column)

--- a/json_test.go
+++ b/json_test.go
@@ -118,6 +118,14 @@ func TestJSON(t *testing.T) {
 			t.Fatalf("failed to find user with json value, got error %v", err)
 		}
 
+		if DB.Dialector.Name() == "postgres" {
+			var results9 []UserWithJSON
+			if err := DB.Where("? = ?", datatypes.JSONQuery("attributes").Extract("name"), "json-2").Find(&results9).Error; err != nil || len(results9) != 1 {
+				t.Fatalf("failed to find user with json value, got error %v", err)
+			}
+			AssertEqual(t, results9[0].Name, users[1].Name)
+		}
+
 		// not support for sqlite
 		// JSONOverlaps
 		//var result9 UserWithJSON


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

This pull request adds support of `Extract()` for `PostgreSQL` driver, just like it was done for MySQL.

This was actually missing and I need it on a project I am working on.

Thank you!

### User Case Description

This method allows to write things like:

```go
DB.Where("? = ?", datatypes.JSONQuery("attributes").Extract("name"), "John")
```