### PR TITLE
fix: JSONQuery.Extract for SQLite3 lacking prefix for path

### DIFF
--- a/json.go
+++ b/json.go
@@ -152,7 +152,7 @@ func (jsonQuery *JSONQueryExpression) Build(builder clause.Builder) {
 				builder.WriteString("JSON_EXTRACT(")
 				builder.WriteQuoted(jsonQuery.column)
 				builder.WriteByte(',')
-				builder.AddVar(stmt, jsonQuery.path)
+				builder.AddVar(stmt, prefix+jsonQuery.path)
 				builder.WriteString(")")
 			case jsonQuery.hasKeys:
 				if len(jsonQuery.keys) > 0 {

--- a/json_test.go
+++ b/json_test.go
@@ -118,13 +118,11 @@ func TestJSON(t *testing.T) {
 			t.Fatalf("failed to find user with json value, got error %v", err)
 		}
 
-		if DB.Dialector.Name() == "postgres" {
-			var results9 []UserWithJSON
-			if err := DB.Where("? = ?", datatypes.JSONQuery("attributes").Extract("name"), "json-2").Find(&results9).Error; err != nil || len(results9) != 1 {
-				t.Fatalf("failed to find user with json value, got error %v", err)
-			}
-			AssertEqual(t, results9[0].Name, users[1].Name)
+		var results9 []UserWithJSON
+		if err := DB.Where("? = ?", datatypes.JSONQuery("attributes").Extract("name"), "json-2").Find(&results9).Error; err != nil || len(results9) != 1 {
+			t.Fatalf("failed to find user with json value, got error %v", err)
 		}
+		AssertEqual(t, results9[0].Name, users[1].Name)
 
 		// not support for sqlite
 		// JSONOverlaps


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Adds prefix (`$.`) to path when building the json_extract expression for sqlite and mysql.

If I correctly read json_extract usages for [SQLite3](https://www.sqlite.org/json1.html#jex) and  [Postgres](https://www.postgresql.org/docs/current/functions-json.html), this prefix should not be added by callers of JSONQuery, since it must not be there for Postgres.

https://github.com/go-gorm/datatypes/blob/a74cb928e9b9ae8435d161c6e4b0afc26d1a0047/json.go#L337
https://github.com/go-gorm/datatypes/blob/a74cb928e9b9ae8435d161c6e4b0afc26d1a0047/json.go#L368

These lines are doing the exact same thing. It more seems a legitimate change for me now.


<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

I was implementing a partial search function for my project which uses sqlite3.

```
db.Where(`? LIKE ?`, datatypes.JSONQuery("some_json_field").Extract("foofoofoo"), "bar"+"%").Find(&something)
```

This did not work, returning an error that prints to `SQL logic error: JSON path error near 'foofoofoo' (1)`

<!-- Your use case -->
