### PR TITLE
add JSONSlice generic for slice data

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ type UserWithJSON struct {
 }
 
 var user = UserWithJSON{
-	Name: "hello"
+	Name: "hello",
 	Attributes: datatypes.JSONType[Attribute]{
 		Data: Attribute{
 			Age:  18,
@@ -207,6 +207,48 @@ jsonMap = UserWithJSON{
 			Tags: []string{"tag1", "tag2", "tag3"},
 		},
 	},
+}
+
+DB.Model(&user).Updates(jsonMap)
+```
+
+NOTE: it's not support json query
+
+## JSONSlice[T]
+
+sqlite, mysql, postgres supported
+
+```go
+import "gorm.io/datatypes"
+
+type Tag struct {
+	Name  string
+	Score float64
+}
+
+type UserWithJSON struct {
+	gorm.Model
+	Name       string
+	Tags       datatypes.JSONSlice[Tag]
+}
+
+var tags = []Tag{{Name: "tag1", Score: 0.1}, {Name: "tag2", Score: 0.2}}
+var user = UserWithJSON{
+	Name: "hello",
+	Tags: datatypes.NewJSONSlice(tags),
+}
+
+// Create
+DB.Create(&user)
+
+// First
+var result UserWithJSON
+DB.First(&result, user.ID)
+
+// Update
+var tags2 = []Tag{{Name: "tag3", Score: 10.1}, {Name: "tag4", Score: 10.2}}
+jsonMap = UserWithJSON{
+	Tags: datatypes.NewJSONSlice(tags2),
 }
 
 DB.Model(&user).Updates(jsonMap)

--- a/json_type.go
+++ b/json_type.go
@@ -19,6 +19,12 @@ type JSONType[T any] struct {
 	Data T
 }
 
+func NewJSONType[T any](data T) JSONType[T] {
+	return JSONType[T]{
+		Data: data,
+	}
+}
+
 // Value return json value, implement driver.Valuer interface
 func (j JSONType[T]) Value() (driver.Value, error) {
 	return json.Marshal(j.Data)
@@ -68,6 +74,63 @@ func (JSONType[T]) GormDBDataType(db *gorm.DB, field *schema.Field) string {
 
 func (js JSONType[T]) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
 	data, _ := js.MarshalJSON()
+
+	switch db.Dialector.Name() {
+	case "mysql":
+		if v, ok := db.Dialector.(*mysql.Dialector); ok && !strings.Contains(v.ServerVersion, "MariaDB") {
+			return gorm.Expr("CAST(? AS JSON)", string(data))
+		}
+	}
+
+	return gorm.Expr("?", string(data))
+}
+
+// JSONSlice give a generic data type for json encoded slice data.
+type JSONSlice[T any] []T
+
+func NewJSONSlice[T any](s []T) JSONSlice[T] {
+	return JSONSlice[T](s)
+}
+
+// Value return json value, implement driver.Valuer interface
+func (j JSONSlice[T]) Value() (driver.Value, error) {
+	return json.Marshal(j)
+}
+
+// Scan scan value into JSONType[T], implements sql.Scanner interface
+func (j *JSONSlice[T]) Scan(value interface{}) error {
+	var bytes []byte
+	switch v := value.(type) {
+	case []byte:
+		bytes = v
+	case string:
+		bytes = []byte(v)
+	default:
+		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
+	}
+	return json.Unmarshal(bytes, &j)
+}
+
+// GormDataType gorm common data type
+func (JSONSlice[T]) GormDataType() string {
+	return "json"
+}
+
+// GormDBDataType gorm db data type
+func (JSONSlice[T]) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	switch db.Dialector.Name() {
+	case "sqlite":
+		return "JSON"
+	case "mysql":
+		return "JSON"
+	case "postgres":
+		return "JSONB"
+	}
+	return ""
+}
+
+func (j JSONSlice[T]) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
+	data, _ := json.Marshal(j)
 
 	switch db.Dialector.Name() {
 	case "mysql":

--- a/json_type_test.go
+++ b/json_type_test.go
@@ -105,11 +105,12 @@ func TestJSONSlice(t *testing.T) {
 			Name  string
 			Score float64
 		}
-		type UserWithJSON struct {
+		type UserWithJSON2 struct {
 			gorm.Model
 			Name string
 			Tags datatypes.JSONSlice[Tag]
 		}
+		type UserWithJSON = UserWithJSON2
 
 		DB.Migrator().DropTable(&UserWithJSON{})
 		if err := DB.Migrator().AutoMigrate(&UserWithJSON{}); err != nil {
@@ -139,11 +140,11 @@ func TestJSONSlice(t *testing.T) {
 		}
 
 		var result UserWithJSON
-		if err := DB.First(&result, users[1].ID).Error; err != nil {
+		if err := DB.First(&result, users[0].ID).Error; err != nil {
 			t.Fatalf("failed to find user with json key, got error %v", err)
 		}
-		AssertEqual(t, result.Name, users[1].Name)
-		AssertEqual(t, result.Tags[0], users[1].Tags[0])
+		AssertEqual(t, result.Name, users[0].Name)
+		AssertEqual(t, result.Tags[0], users[0].Tags[0])
 
 		// FirstOrCreate
 		jsonMap := UserWithJSON{

--- a/json_type_test.go
+++ b/json_type_test.go
@@ -51,6 +51,12 @@ func TestJSONType(t *testing.T) {
 		}, {
 			Name:       "json-3",
 			Attributes: newJSONType[Attribute]([]byte(`{"tags": ["tag1","tag2","tag3"]`)),
+		}, {
+			Name:       "json-4",
+			Attributes: datatypes.NewJSONType(Attribute{Tags: []string{"tag1", "tag2", "tag3"}}),
+		}, {
+			Name:       "json-5",
+			Attributes: datatypes.JSONType[Attribute]{Data: Attribute{Tags: []string{"tag1", "tag2", "tag3"}}},
 		}}
 
 		if err := DB.Create(&users).Error; err != nil {
@@ -89,6 +95,72 @@ func TestJSONType(t *testing.T) {
 		result3.ID = 1
 		if err := DB.Model(&result3).Updates(jsonMap).Error; err != nil {
 			t.Errorf("failed to run FirstOrCreate")
+		}
+	}
+}
+
+func TestJSONSlice(t *testing.T) {
+	if SupportedDriver("sqlite", "mysql", "postgres") {
+		type Tag struct {
+			Name  string
+			Score float64
+		}
+		type UserWithJSON struct {
+			gorm.Model
+			Name string
+			Tags datatypes.JSONSlice[Tag]
+		}
+
+		DB.Migrator().DropTable(&UserWithJSON{})
+		if err := DB.Migrator().AutoMigrate(&UserWithJSON{}); err != nil {
+			t.Errorf("failed to migrate, got error: %v", err)
+		}
+
+		// Go's json marshaler removes whitespace & orders keys alphabetically
+		// use to compare against marshaled []byte of datatypes.JSON
+		var tags = []Tag{{Name: "tag1", Score: 0.1}, {Name: "tag2", Score: 0.2}}
+
+		users := []UserWithJSON{{
+			Name: "json-1",
+			Tags: datatypes.JSONSlice[Tag]{{Name: "tag1", Score: 1.1}, {Name: "tag2", Score: 1.2}},
+		}, {
+			Name: "json-2",
+			Tags: datatypes.NewJSONSlice([]Tag{{Name: "tag3", Score: 0.3}, {Name: "tag4", Score: 0.4}}),
+		}, {
+			Name: "json-3",
+			Tags: datatypes.JSONSlice[Tag](tags),
+		}, {
+			Name: "json-4",
+			Tags: datatypes.NewJSONSlice(tags),
+		}}
+
+		if err := DB.Create(&users).Error; err != nil {
+			t.Errorf("Failed to create users %v", err)
+		}
+
+		var result UserWithJSON
+		if err := DB.First(&result, users[1].ID).Error; err != nil {
+			t.Fatalf("failed to find user with json key, got error %v", err)
+		}
+		AssertEqual(t, result.Name, users[1].Name)
+		AssertEqual(t, result.Tags[0], users[1].Tags[0])
+
+		// FirstOrCreate
+		jsonMap := UserWithJSON{
+			Tags: datatypes.NewJSONSlice(tags),
+		}
+		if err := DB.Where(&UserWithJSON{Name: "json-1"}).Assign(jsonMap).FirstOrCreate(&UserWithJSON{}).Error; err != nil {
+			t.Errorf("failed to run FirstOrCreate")
+		}
+
+		// Update
+		jsonMap = UserWithJSON{
+			Tags: datatypes.NewJSONSlice(tags),
+		}
+		var result3 UserWithJSON
+		result3.ID = 1
+		if err := DB.Model(&result3).Updates(jsonMap).Error; err != nil {
+			t.Errorf("failed to run Updates")
 		}
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

1. add `type JSONSlice[T any] []T` for generic type slice data.

why not use `JSONType[[]T]` ?  

because `JSONSlice` is good for reflection, but `JSONType` is not.


for example

```golang
type User struct {
    Tags  JSONSlice[Tag]
    Tags2 JSONType[[]Tag]
}
```
when we use json to marshal the value we can got

```json
{
   "tags":  [{"name": "tag1", "score":  1.0}],
   "tags2":  [{"name": "tag1", "score":  1.0}]
}
```

but we use other decode/encode/reflect method  to process data (like https://github.com/mitchellh/mapstructure)

it will got an extra `data` level, cause `JSONType` with an extra `Data` Field 
```
{
   "tags":  [{"name": "tag1", "score":  1.0}],
   "tags2": {
       "data": [{"name": "tag1", "score":  1.0}],
   }
}
```

golang do not support the generic type alias  like`type JSONType[T any] T`  to auto bind the `Value`/ `Scan`  method.


so, add a `JSONSlice` can solve this problem just for the slice value.



### User Case Description

see the json_type_test.go

```golang
		type Tag struct {
			Name  string
			Score float64
		}
		type UserWithJSON struct {
			gorm.Model
			Name string
			Tags datatypes.JSONSlice[Tag]
		}

		var tags = []Tag{{Name: "tag1", Score: 0.1}, {Name: "tag2", Score: 0.2}}
                 var user = UserWithJSON{
			Name: "json-4",
			Tags: datatypes.NewJSONSlice(tags),
		}
                DB.Create(&users)
```

