### PR TITLE
Draft: fix JSONType[T] Pluck query error

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ jsonMap = UserWithJSON{
 DB.Model(&user).Updates(jsonMap)
 ```
 
-NOTE: it's not support json query
+NOTE: it's not support json query and `db.Pluck` method
 
 ## JSONArray
 

--- a/json_type.go
+++ b/json_type.go
@@ -16,18 +16,23 @@ import (
 
 // JSONType give a generic data type for json encoded data.
 type JSONType[T any] struct {
-	Data T
+	data T
 }
 
 func NewJSONType[T any](data T) JSONType[T] {
 	return JSONType[T]{
-		Data: data,
+		data: data,
 	}
+}
+
+// Data return data with generic Type T
+func (j JSONType[T]) Data() T {
+	return j.data
 }
 
 // Value return json value, implement driver.Valuer interface
 func (j JSONType[T]) Value() (driver.Value, error) {
-	return json.Marshal(j.Data)
+	return json.Marshal(j.data)
 }
 
 // Scan scan value into JSONType[T], implements sql.Scanner interface
@@ -41,17 +46,17 @@ func (j *JSONType[T]) Scan(value interface{}) error {
 	default:
 		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
 	}
-	return json.Unmarshal(bytes, &j.Data)
+	return json.Unmarshal(bytes, &j.data)
 }
 
 // MarshalJSON to output non base64 encoded []byte
 func (j JSONType[T]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(j.Data)
+	return json.Marshal(j.data)
 }
 
 // UnmarshalJSON to deserialize []byte
 func (j *JSONType[T]) UnmarshalJSON(b []byte) error {
-	return json.Unmarshal(b, &j.Data)
+	return json.Unmarshal(b, &j.data)
 }
 
 // GormDataType gorm common data type


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [ ] Non breaking API changes
- [x] Tested

### What did this pull request do?

This is a fix MR for https://github.com/go-gorm/datatypes/issues/200

and this cause a little breaking change in JSONType[T] usage

<!--
provide a general description of the code changes in your pull request
-->
#### the bug
I ever post PR https://github.com/go-gorm/datatypes/pull/174 , but  I didn't have test enough for ALL gorm query API.
this exported `Data T` field worked well in `Find`, `First` method, and added  in json_type_test.go.
and `Data() T` method is not so efficient than directly exported field ,  but it is wrong.


This issue  https://github.com/go-gorm/datatypes/issues/200 give a bad case query in `Pluck`


Gorm found the  input ptr of value `var field = &JSONType[*User]`  is a struct , and have an exported Field `Data T`
so it goto the this Struct's schema.Fields logic, and found this struct's `Data T ` and checked `field.DataType == ""`

https://github.com/go-gorm/gorm/blob/532e9cf4ccce927249bcb102c09e4a9093aae4fe/schema/schema.go#L280-L283

so finally  got an error

```
[error] invalid field found for struct gorm.io/datatypes.JSONType[*main.User]'s field Data: define a valid foreign key for relations or implement the Valuer/Scanner interface
find field in row  <nil> &{name 18}
```

#### the fix

I research the gorm and found it only collect `ast.IsExported` Field to scheme.Fields 

and the `JSONType[T]` provide generic method `Valuer` and `Scaner` is only for a field not for another relation Table.

so I think make `Data` unexported is a better fix solution.

#### what about the breaking change 

I this this breaking is small, and easy enough to change 

```
result.Data ----> result.Data()
```
If same name is not ok. may be change to `result.GetData()`


Feel sorry to introduce some bug and cause a break change😢 

### User Case Description

```go
		type Attribute struct {
			Sex   int
			Age   int
			Orgs  map[string]string
			Tags  []string
			Admin bool
			Role  string
		}
		type UserWithJSON struct {
			gorm.Model
			Name       string
			Attributes datatypes.JSONType[Attribute]
		}

		// Pluck
		var attr datatypes.JSONType[Attribute]
		DB.Model(&UserWithJSON{}).Limit(1).Order("id asc").Pluck("attributes", &attr)
		var attribute = attr.Data()
		AssertEqual(t, attribute.Age, 18)
```

### Note for JSONSlice[T]

sadly `db.Pluck` still failed for JSONSlice[T] dest, because  gorm will reflect the dest and process the Array and Slice

```go
		reflectValueType := reflectValue.Type()
		switch reflectValueType.Kind() {
		case reflect.Array, reflect.Slice:
			reflectValueType = reflectValueType.Elem()
		}
```

so, I add a `Note` in README.md for JSONSlice[T]
