### PR TITLE
Use json.Number when scan to JSONMap

### DIFF
--- a/json_map.go
+++ b/json_map.go
@@ -1,6 +1,7 @@
 package datatypes
 
 import (
+	"bytes"
 	"context"
 	"database/sql/driver"
 	"encoding/json"
@@ -42,7 +43,10 @@ func (m *JSONMap) Scan(val interface{}) error {
 		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", val))
 	}
 	t := map[string]interface{}{}
-	err := json.Unmarshal(ba, &t)
+	rd := bytes.NewReader(ba)
+	decoder := json.NewDecoder(rd)
+	decoder.UseNumber()
+	err := decoder.Decode(&t)
 	*m = t
 	return err
 }

--- a/json_map_test.go
+++ b/json_map_test.go
@@ -172,3 +172,13 @@ func TestJSONMap(t *testing.T) {
 		}
 	}
 }
+
+func TestJSONMap_Scan(t *testing.T) {
+	content := `{"user_id": 1085238870184050699, "name": "Name of user"}`
+	obj := make(datatypes.JSONMap)
+	err := obj.Scan([]byte(content))
+	if err != nil {
+		t.Fatalf("decode error %v", err)
+	}
+	AssertEqual(t, obj["user_id"], 1085238870184050699)
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?
Use `json.Decoder.UseNumber()` when Scan `[]byte` to `JSONMap`

### User Case Description
When scanning `JSONMap` (a.k.a `map[string]interface{}`) from `[]byte`, it returns the incorrect value of `int64` and `uint64` if the value is more than 18 digits. The reason is by default `json.Unmarshal` treat `int64` and `uint64` as `float64` and loses the numeric precision. 
For example
```Golang
content := `{"user_id": 1085238870184050699, "name": "Name of user"}`
obj := make(datatypes.JSONMap)
obj.Scan([]byte(content))
fmt.Print(obj["user_id"])
// before: obj["user_id"] = 1.0852388701840507e+18 <-- incorrect value
// after: obj["user_id"] = 1085238870184050699 <-- correct value
fmt.Print(cast.ToInt64(obj["user_id"])) // use github.com/spf13/cast
// before: obj["user_id"] = 1085238870184050688 <-- incorrect value
// after: obj["user_id"] = 1085238870184050699 <-- correct value
```