### PR TITLE
feature: add Mysql&Postgres Json Like

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -124,6 +124,12 @@ func TestJSON(t *testing.T) {
 		}
 		AssertEqual(t, results9[0].Name, users[1].Name)
 
+		var result10 UserWithJSON
+		if err := DB.First(&result10, datatypes.JSONQuery("attributes").Likes("%dmi%", "role")).Error; err != nil {
+			t.Fatalf("failed to find user with json value, got error %v", err)
+		}
+		AssertEqual(t, result10.Name, users[1].Name)
+
 		// not support for sqlite
 		// JSONOverlaps
 		//var result9 UserWithJSON


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Add Likes function on JSONQueryExpression

### User Case Description

`
type UserWithJSON struct {
	gorm.Model
	Name       string
	Attributes datatypes.JSON
}

DB.Create(&User{
	Name:       "json-1",
	Attributes: datatypes.JSON([]byte(`{"name": "jinzhu", "age": 18, "tags": ["tag1", "tag2"], "orgs": {"orga": "orga"}}`)),
}

var result UserWithJSON
DB.First(&result, datatypes.JSONQuery("attributes").Likes("%jin%", "name"))
`
