### PR TITLE
JSONArrayExpression support sqlite and postgres

### DIFF
--- a/json.go
+++ b/json.go
@@ -467,6 +467,14 @@ func (json *JSONArrayExpression) Build(builder clause.Builder) {
 			builder.WriteString("JSON_CONTAINS (" + stmt.Quote(json.column) + ", JSON_ARRAY(")
 			builder.AddVar(stmt, json.equalsValue)
 			builder.WriteString("))")
+		case "sqlite":
+			builder.WriteString("exists(SELECT 1 FROM json_each(" + stmt.Quote(json.column) + ") WHERE value = ")
+			builder.AddVar(stmt, json.equalsValue)
+			builder.WriteString(")")
+		case "postgres":
+			builder.WriteString(stmt.Quote(json.column))
+			builder.WriteString(" ? ")
+			builder.AddVar(stmt, json.equalsValue)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

JSONArrayExpression support sqlite and postgres

### User Case Description

```go
var retMultiple []Param
DB.Where(datatypes.JSONArrayQuery("config").Contains("c")).Find(&retMultiple)
```
