### PR TITLE
feature: Add datatype for uuid.UUID (Google UUID)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gorm.io/datatypes
 go 1.19
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/jinzhu/now v1.1.5
 	gorm.io/driver/mysql v1.5.6
 	gorm.io/driver/postgres v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2V
 github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei6A=
 github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EOqtpKwwwHI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=

--- a/uuid.go
+++ b/uuid.go
@@ -10,6 +10,14 @@ import (
 
 type UUID uuid.UUID
 
+func NewUUIDv1() UUID {
+	return UUID(uuid.Must(uuid.NewUUID()))
+}
+
+func NewUUIDv4() UUID {
+	return UUID(uuid.Must(uuid.NewRandom()))
+}
+
 // GormDataType gorm common data type
 func (UUID) GormDataType() string {
 	return "string"

--- a/uuid.go
+++ b/uuid.go
@@ -1,0 +1,73 @@
+package datatypes
+
+import (
+	"database/sql/driver"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+type UUID uuid.UUID
+
+// GormDataType gorm common data type
+func (UUID) GormDataType() string {
+	return "string"
+}
+
+// GormDBDataType gorm db data type
+func (UUID) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	switch db.Dialector.Name() {
+	case "mysql":
+		return "LONGTEXT"
+	case "postgres":
+		return "UUID"
+	case "sqlserver":
+		return "NVARCHAR"
+	case "sqlite":
+		return "TEXT"
+	default:
+		return ""
+	}
+}
+
+func (u *UUID) Scan(value interface{}) error {
+	var result uuid.UUID
+	if err := result.Scan(value); err != nil {
+		return err
+	}
+	*u = UUID(result)
+	return nil
+}
+
+func (u UUID) Value() (driver.Value, error) {
+	return uuid.UUID(u).Value()
+}
+
+func (u UUID) String() string {
+	return uuid.UUID(u).String()
+}
+
+func (u UUID) Equals(other UUID) bool {
+	return u.String() == other.String()
+}
+
+func (u UUID) Length() int {
+	return len(u.String())
+}
+
+func (u UUID) IsNil() bool {
+	return uuid.UUID(u) == uuid.Nil
+}
+
+func (u UUID) IsEmpty() bool {
+	return u.IsNil() || u.Length() == 0
+}
+
+func (u *UUID) IsNilPtr() bool {
+	return u == nil
+}
+
+func (u *UUID) IsEmptyPtr() bool {
+	return u.IsNilPtr() || u.IsEmpty()
+}

--- a/uuid.go
+++ b/uuid.go
@@ -10,20 +10,22 @@ import (
 
 type UUID uuid.UUID
 
+// NewUUIDv1 generates a UUID version 1, panics on generation failure.
 func NewUUIDv1() UUID {
 	return UUID(uuid.Must(uuid.NewUUID()))
 }
 
+// NewUUIDv4 generates a UUID version 4, panics on generation failure.
 func NewUUIDv4() UUID {
 	return UUID(uuid.Must(uuid.NewRandom()))
 }
 
-// GormDataType gorm common data type
+// GormDataType gorm common data type.
 func (UUID) GormDataType() string {
 	return "string"
 }
 
-// GormDBDataType gorm db data type
+// GormDBDataType gorm db data type.
 func (UUID) GormDBDataType(db *gorm.DB, field *schema.Field) string {
 	switch db.Dialector.Name() {
 	case "mysql":
@@ -39,6 +41,7 @@ func (UUID) GormDBDataType(db *gorm.DB, field *schema.Field) string {
 	}
 }
 
+// Scan is the scanner function for this datatype.
 func (u *UUID) Scan(value interface{}) error {
 	var result uuid.UUID
 	if err := result.Scan(value); err != nil {
@@ -48,34 +51,42 @@ func (u *UUID) Scan(value interface{}) error {
 	return nil
 }
 
+// Value is the valuer function for this datatype.
 func (u UUID) Value() (driver.Value, error) {
 	return uuid.UUID(u).Value()
 }
 
+// String returns the string form of the UUID.
 func (u UUID) String() string {
 	return uuid.UUID(u).String()
 }
 
+// Equals returns true if string form of UUID matches other, false otherwise.
 func (u UUID) Equals(other UUID) bool {
 	return u.String() == other.String()
 }
 
+// Length returns the number of characters in string form of UUID.
 func (u UUID) Length() int {
 	return len(u.String())
 }
 
+// IsNil returns true if the UUID is a nil UUID (all zeroes), false otherwise.
 func (u UUID) IsNil() bool {
 	return uuid.UUID(u) == uuid.Nil
 }
 
+// IsEmpty returns true if UUID is nil UUID or of zero length, false otherwise.
 func (u UUID) IsEmpty() bool {
 	return u.IsNil() || u.Length() == 0
 }
 
+// IsNilPtr returns true if caller UUID ptr is nil, false otherwise.
 func (u *UUID) IsNilPtr() bool {
 	return u == nil
 }
 
+// IsEmptyPtr returns true if caller UUID ptr is nil or it's value is empty.
 func (u *UUID) IsEmptyPtr() bool {
 	return u.IsNilPtr() || u.IsEmpty()
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -25,35 +25,18 @@ func TestUUID(t *testing.T) {
 			t.Errorf("failed to migrate, got error: %v", err)
 		}
 
-		user1UUID, uuidGenErr := uuid.NewUUID()
-		if uuidGenErr != nil {
-			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
-		}
-		user2UUID, uuidGenErr := uuid.NewUUID()
-		if uuidGenErr != nil {
-			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
-		}
-		user3UUID, uuidGenErr := uuid.NewUUID()
-		if uuidGenErr != nil {
-			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
-		}
-		user4UUID, uuidGenErr := uuid.NewUUID()
-		if uuidGenErr != nil {
-			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
-		}
-
 		users := []UserWithUUID{{
 			Name:     "uuid-1",
-			UserUUID: datatypes.UUID(user1UUID),
+			UserUUID: datatypes.NewUUIDv1(),
 		}, {
 			Name:     "uuid-2",
-			UserUUID: datatypes.UUID(user2UUID),
+			UserUUID: datatypes.NewUUIDv1(),
 		}, {
 			Name:     "uuid-3",
-			UserUUID: datatypes.UUID(user3UUID),
+			UserUUID: datatypes.NewUUIDv4(),
 		}, {
 			Name:     "uuid-4",
-			UserUUID: datatypes.UUID(user4UUID),
+			UserUUID: datatypes.NewUUIDv4(),
 		}}
 
 		if err := DB.Create(&users).Error; err != nil {
@@ -115,27 +98,10 @@ func TestUUIDPtr(t *testing.T) {
 			t.Errorf("failed to migrate, got error: %v", err)
 		}
 
-		user1UUID, uuidGenErr := uuid.NewUUID()
-		if uuidGenErr != nil {
-			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
-		}
-		user2UUID, uuidGenErr := uuid.NewUUID()
-		if uuidGenErr != nil {
-			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
-		}
-		user3UUID, uuidGenErr := uuid.NewUUID()
-		if uuidGenErr != nil {
-			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
-		}
-		user4UUID, uuidGenErr := uuid.NewUUID()
-		if uuidGenErr != nil {
-			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
-		}
-
-		uuid1 := datatypes.UUID(user1UUID)
-		uuid2 := datatypes.UUID(user2UUID)
-		uuid3 := datatypes.UUID(user3UUID)
-		uuid4 := datatypes.UUID(user4UUID)
+		uuid1 := datatypes.NewUUIDv1()
+		uuid2 := datatypes.NewUUIDv1()
+		uuid3 := datatypes.NewUUIDv4()
+		uuid4 := datatypes.NewUUIDv4()
 
 		users := []UserWithUUIDPtr{{
 			Name:     "uuid-1",

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,0 +1,187 @@
+package datatypes_test
+
+import (
+	"database/sql/driver"
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	. "gorm.io/gorm/utils/tests"
+)
+
+var _ driver.Valuer = &datatypes.UUID{}
+
+func TestUUID(t *testing.T) {
+	if SupportedDriver("sqlite", "mysql", "postgres", "sqlserver") {
+		type UserWithUUID struct {
+			gorm.Model
+			Name     string
+			UserUUID datatypes.UUID
+		}
+
+		DB.Migrator().DropTable(&UserWithUUID{})
+		if err := DB.Migrator().AutoMigrate(&UserWithUUID{}); err != nil {
+			t.Errorf("failed to migrate, got error: %v", err)
+		}
+
+		user1UUID, uuidGenErr := uuid.NewUUID()
+		if uuidGenErr != nil {
+			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
+		}
+		user2UUID, uuidGenErr := uuid.NewUUID()
+		if uuidGenErr != nil {
+			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
+		}
+		user3UUID, uuidGenErr := uuid.NewUUID()
+		if uuidGenErr != nil {
+			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
+		}
+		user4UUID, uuidGenErr := uuid.NewUUID()
+		if uuidGenErr != nil {
+			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
+		}
+
+		users := []UserWithUUID{{
+			Name:     "uuid-1",
+			UserUUID: datatypes.UUID(user1UUID),
+		}, {
+			Name:     "uuid-2",
+			UserUUID: datatypes.UUID(user2UUID),
+		}, {
+			Name:     "uuid-3",
+			UserUUID: datatypes.UUID(user3UUID),
+		}, {
+			Name:     "uuid-4",
+			UserUUID: datatypes.UUID(user4UUID),
+		}}
+
+		if err := DB.Create(&users).Error; err != nil {
+			t.Errorf("Failed to create users %v", err)
+		}
+
+		for _, user := range users {
+			result := UserWithUUID{}
+			if err := DB.First(
+				&result, "name = ? AND user_uuid = ?",
+				user.Name,
+				user.UserUUID,
+			).Error; err != nil {
+				t.Fatalf("failed to find user with uuid, got error: %v", err)
+			}
+			AssertEqual(t, !result.UserUUID.IsEmpty(), true)
+			AssertEqual(t, user.UserUUID.Equals(result.UserUUID), true)
+			valueUser, err := user.UserUUID.Value()
+			if err != nil {
+				t.Fatalf("failed to get user value, got error: %v", err)
+			}
+			valueResult, err := result.UserUUID.Value()
+			if err != nil {
+				t.Fatalf("failed to get result value, got error: %v", err)
+			}
+			AssertEqual(t, valueUser, valueResult)
+		}
+
+		user1 := users[0]
+		AssertEqual(t, user1.UserUUID.IsNil(), false)
+		AssertEqual(t, user1.UserUUID.IsEmpty(), false)
+		DB.Model(&user1).Updates(
+			map[string]interface{}{"user_uuid": uuid.Nil},
+		)
+		AssertEqual(t, user1.UserUUID.IsNil(), true)
+		AssertEqual(t, user1.UserUUID.IsEmpty(), true)
+
+		user2 := users[1]
+		AssertEqual(t, user2.UserUUID.IsNil(), false)
+		AssertEqual(t, user2.UserUUID.IsEmpty(), false)
+		DB.Model(&user2).Updates(
+			map[string]interface{}{"user_uuid": nil},
+		)
+		AssertEqual(t, user2.UserUUID.IsNil(), true)
+		AssertEqual(t, user2.UserUUID.IsEmpty(), true)
+	}
+}
+
+func TestUUIDPtr(t *testing.T) {
+	if SupportedDriver("sqlite", "mysql", "postgres", "sqlserver") {
+		type UserWithUUIDPtr struct {
+			gorm.Model
+			Name     string
+			UserUUID *datatypes.UUID
+		}
+
+		DB.Migrator().DropTable(&UserWithUUIDPtr{})
+		if err := DB.Migrator().AutoMigrate(&UserWithUUIDPtr{}); err != nil {
+			t.Errorf("failed to migrate, got error: %v", err)
+		}
+
+		user1UUID, uuidGenErr := uuid.NewUUID()
+		if uuidGenErr != nil {
+			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
+		}
+		user2UUID, uuidGenErr := uuid.NewUUID()
+		if uuidGenErr != nil {
+			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
+		}
+		user3UUID, uuidGenErr := uuid.NewUUID()
+		if uuidGenErr != nil {
+			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
+		}
+		user4UUID, uuidGenErr := uuid.NewUUID()
+		if uuidGenErr != nil {
+			t.Fatalf("failed to generate a new UUID, got error %v", uuidGenErr)
+		}
+
+		uuid1 := datatypes.UUID(user1UUID)
+		uuid2 := datatypes.UUID(user2UUID)
+		uuid3 := datatypes.UUID(user3UUID)
+		uuid4 := datatypes.UUID(user4UUID)
+
+		users := []UserWithUUIDPtr{{
+			Name:     "uuid-1",
+			UserUUID: &uuid1,
+		}, {
+			Name:     "uuid-2",
+			UserUUID: &uuid2,
+		}, {
+			Name:     "uuid-3",
+			UserUUID: &uuid3,
+		}, {
+			Name:     "uuid-4",
+			UserUUID: &uuid4,
+		}}
+
+		if err := DB.Create(&users).Error; err != nil {
+			t.Errorf("Failed to create users %v", err)
+		}
+
+		for _, user := range users {
+			result := UserWithUUIDPtr{}
+			if err := DB.First(
+				&result, "name = ? AND user_uuid = ?",
+				user.Name,
+				*user.UserUUID,
+			).Error; err != nil {
+				t.Fatalf("failed to find user with uuid, got error: %v", err)
+			}
+			AssertEqual(t, !result.UserUUID.IsEmpty(), true)
+			AssertEqual(t, user.UserUUID, result.UserUUID)
+			valueUser, err := user.UserUUID.Value()
+			if err != nil {
+				t.Fatalf("failed to get user value, got error: %v", err)
+			}
+			valueResult, err := result.UserUUID.Value()
+			if err != nil {
+				t.Fatalf("failed to get result value, got error: %v", err)
+			}
+			AssertEqual(t, valueUser, valueResult)
+		}
+
+		user1 := users[0]
+		AssertEqual(t, user1.UserUUID.IsNilPtr(), false)
+		AssertEqual(t, user1.UserUUID.IsEmptyPtr(), false)
+		DB.Model(&user1).Updates(map[string]interface{}{"user_uuid": nil})
+		AssertEqual(t, user1.UserUUID.IsNilPtr(), true)
+		AssertEqual(t, user1.UserUUID.IsEmptyPtr(), true)
+	}
+}


### PR DESCRIPTION
# feature: Add datatype for uuid.UUID (Google UUID)
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [*] Do only one thing
- [*] Non breaking API changes
- [*] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

This PR adds datatype for `uuid.UUID` along with supporting tests.

### User Case Description

<!-- Your use case -->
The [Google UUID package](https://github.com/google/uuid) is a very popular package among Go developers. Since it's used so widely and so often, it'll be great to abstract it out as a separate gorm datatype. This came up as per the discussion on [this Gorm PR](https://github.com/go-gorm/gorm/pull/7099) with @a631807682 and @itanken.
