### PR TITLE
feature: Add datatype BinUUID for uuid as binary storage in DB

### DIFF
--- a/binuuid.go
+++ b/binuuid.go
@@ -1,0 +1,120 @@
+package datatypes
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"errors"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+// This datatype is similar to datatypes.UUID, major difference being that
+// this datatype stores the uuid in the database as a binary (byte) array
+// instead of a string. Developers may use either as per their preference.
+type BinUUID uuid.UUID
+
+// NewBinUUIDv1 generates a uuid version 1, panics on generation failure.
+func NewBinUUIDv1() BinUUID {
+	return BinUUID(uuid.Must(uuid.NewUUID()))
+}
+
+// NewBinUUIDv4 generates a uuid version 4, panics on generation failure.
+func NewBinUUIDv4() BinUUID {
+	return BinUUID(uuid.Must(uuid.NewRandom()))
+}
+
+// BinUUIDFromString returns the BinUUID representation of the specified uuidStr.
+func BinUUIDFromString(uuidStr string) BinUUID {
+	return BinUUID(uuid.MustParse(uuidStr))
+}
+
+// GormDataType gorm common data type.
+func (BinUUID) GormDataType() string {
+	return "BINARY(16)"
+}
+
+// GormDBDataType gorm db data type.
+func (BinUUID) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	switch db.Dialector.Name() {
+	case "mysql":
+		return "BINARY(16)"
+	case "postgres":
+		return "BYTEA"
+	case "sqlserver":
+		return "BINARY(16)"
+	case "sqlite":
+		return "BLOB"
+	default:
+		return ""
+	}
+}
+
+// Scan is the scanner function for this datatype.
+func (u *BinUUID) Scan(value interface{}) error {
+	valueBytes, ok := value.([]byte)
+	if !ok {
+		return errors.New("unable to convert value to bytes")
+	}
+	valueUUID, err := uuid.FromBytes(valueBytes)
+	if err != nil {
+		return err
+	}
+	*u = BinUUID(valueUUID)
+	return nil
+}
+
+// Value is the valuer function for this datatype.
+func (u BinUUID) Value() (driver.Value, error) {
+	return uuid.UUID(u).MarshalBinary()
+}
+
+// String returns the string form of the UUID.
+func (u BinUUID) Bytes() []byte {
+	bytes, err := uuid.UUID(u).MarshalBinary()
+	if err != nil {
+		return nil
+	}
+	return bytes
+}
+
+// String returns the string form of the UUID.
+func (u BinUUID) String() string {
+	return uuid.UUID(u).String()
+}
+
+// Equals returns true if bytes form of BinUUID matches other, false otherwise.
+func (u BinUUID) Equals(other BinUUID) bool {
+	return bytes.Equal(u.Bytes(), other.Bytes())
+}
+
+// Length returns the number of characters in string form of UUID.
+func (u BinUUID) LengthBytes() int {
+	return len(u.Bytes())
+}
+
+// Length returns the number of characters in string form of UUID.
+func (u BinUUID) Length() int {
+	return len(u.String())
+}
+
+// IsNil returns true if the BinUUID is nil uuid (all zeroes), false otherwise.
+func (u BinUUID) IsNil() bool {
+	return uuid.UUID(u) == uuid.Nil
+}
+
+// IsEmpty returns true if BinUUID is nil uuid or of zero length, false otherwise.
+func (u BinUUID) IsEmpty() bool {
+	return u.IsNil() || u.Length() == 0
+}
+
+// IsNilPtr returns true if caller BinUUID ptr is nil, false otherwise.
+func (u *BinUUID) IsNilPtr() bool {
+	return u == nil
+}
+
+// IsEmptyPtr returns true if caller BinUUID ptr is nil or it's value is empty.
+func (u *BinUUID) IsEmptyPtr() bool {
+	return u.IsNilPtr() || u.IsEmpty()
+}

--- a/binuuid_test.go
+++ b/binuuid_test.go
@@ -10,33 +10,33 @@ import (
 	. "gorm.io/gorm/utils/tests"
 )
 
-var _ driver.Valuer = &datatypes.UUID{}
+var _ driver.Valuer = &datatypes.BinUUID{}
 
-func TestUUID(t *testing.T) {
+func TestBinUUID(t *testing.T) {
 	if SupportedDriver("sqlite", "mysql", "postgres", "sqlserver") {
-		type UserWithUUID struct {
+		type UserWithBinUUID struct {
 			gorm.Model
 			Name     string
-			UserUUID datatypes.UUID
+			UserUUID datatypes.BinUUID
 		}
 
-		DB.Migrator().DropTable(&UserWithUUID{})
-		if err := DB.Migrator().AutoMigrate(&UserWithUUID{}); err != nil {
+		DB.Migrator().DropTable(&UserWithBinUUID{})
+		if err := DB.Migrator().AutoMigrate(&UserWithBinUUID{}); err != nil {
 			t.Errorf("failed to migrate, got error: %v", err)
 		}
 
-		users := []UserWithUUID{{
+		users := []UserWithBinUUID{{
 			Name:     "uuid-1",
-			UserUUID: datatypes.NewUUIDv1(),
+			UserUUID: datatypes.NewBinUUIDv1(),
 		}, {
 			Name:     "uuid-2",
-			UserUUID: datatypes.NewUUIDv1(),
+			UserUUID: datatypes.NewBinUUIDv1(),
 		}, {
 			Name:     "uuid-3",
-			UserUUID: datatypes.NewUUIDv4(),
+			UserUUID: datatypes.NewBinUUIDv4(),
 		}, {
 			Name:     "uuid-4",
-			UserUUID: datatypes.NewUUIDv4(),
+			UserUUID: datatypes.NewBinUUIDv4(),
 		}}
 
 		if err := DB.Create(&users).Error; err != nil {
@@ -44,7 +44,7 @@ func TestUUID(t *testing.T) {
 		}
 
 		for _, user := range users {
-			result := UserWithUUID{}
+			result := UserWithBinUUID{}
 			if err := DB.First(
 				&result, "name = ? AND user_uuid = ?",
 				user.Name,
@@ -63,6 +63,7 @@ func TestUUID(t *testing.T) {
 				t.Fatalf("failed to get result value, got error: %v", err)
 			}
 			AssertEqual(t, valueUser, valueResult)
+			AssertEqual(t, user.UserUUID.LengthBytes(), 16)
 			AssertEqual(t, user.UserUUID.Length(), 36)
 		}
 
@@ -71,12 +72,14 @@ func TestUUID(t *testing.T) {
 		AssertEqual(t, user1.UserUUID.IsNil(), false)
 		AssertEqual(t, user1.UserUUID.IsEmpty(), false)
 		tx = DB.Model(&user1).Updates(
-			map[string]interface{}{"user_uuid": uuid.Nil},
+			map[string]interface{}{
+				"user_uuid": datatypes.BinUUIDFromString(uuid.Nil.String()),
+			},
 		)
 		AssertEqual(t, tx.Error, nil)
 		AssertEqual(t, user1.UserUUID.IsNil(), true)
 		AssertEqual(t, user1.UserUUID.IsEmpty(), true)
-		user1NewUUID := datatypes.NewUUIDv4()
+		user1NewUUID := datatypes.NewBinUUIDv4()
 		tx = DB.Model(&user1).Updates(
 			map[string]interface{}{
 				"user_uuid": user1NewUUID,
@@ -94,7 +97,7 @@ func TestUUID(t *testing.T) {
 		AssertEqual(t, tx.Error, nil)
 		AssertEqual(t, user2.UserUUID.IsNil(), true)
 		AssertEqual(t, user2.UserUUID.IsEmpty(), true)
-		user2NewUUID := datatypes.NewUUIDv4()
+		user2NewUUID := datatypes.NewBinUUIDv4()
 		tx = DB.Model(&user2).Updates(
 			map[string]interface{}{
 				"user_uuid": user2NewUUID,
@@ -105,25 +108,25 @@ func TestUUID(t *testing.T) {
 	}
 }
 
-func TestUUIDPtr(t *testing.T) {
+func TestBinUUIDPtr(t *testing.T) {
 	if SupportedDriver("sqlite", "mysql", "postgres", "sqlserver") {
-		type UserWithUUIDPtr struct {
+		type UserWithBinUUIDPtr struct {
 			gorm.Model
 			Name     string
-			UserUUID *datatypes.UUID
+			UserUUID *datatypes.BinUUID
 		}
 
-		DB.Migrator().DropTable(&UserWithUUIDPtr{})
-		if err := DB.Migrator().AutoMigrate(&UserWithUUIDPtr{}); err != nil {
+		DB.Migrator().DropTable(&UserWithBinUUIDPtr{})
+		if err := DB.Migrator().AutoMigrate(&UserWithBinUUIDPtr{}); err != nil {
 			t.Errorf("failed to migrate, got error: %v", err)
 		}
 
-		uuid1 := datatypes.NewUUIDv1()
-		uuid2 := datatypes.NewUUIDv1()
-		uuid3 := datatypes.NewUUIDv4()
-		uuid4 := datatypes.NewUUIDv4()
+		uuid1 := datatypes.NewBinUUIDv1()
+		uuid2 := datatypes.NewBinUUIDv1()
+		uuid3 := datatypes.NewBinUUIDv4()
+		uuid4 := datatypes.NewBinUUIDv4()
 
-		users := []UserWithUUIDPtr{{
+		users := []UserWithBinUUIDPtr{{
 			Name:     "uuid-1",
 			UserUUID: &uuid1,
 		}, {
@@ -142,7 +145,7 @@ func TestUUIDPtr(t *testing.T) {
 		}
 
 		for _, user := range users {
-			result := UserWithUUIDPtr{}
+			result := UserWithBinUUIDPtr{}
 			if err := DB.First(
 				&result, "name = ? AND user_uuid = ?",
 				user.Name,
@@ -161,6 +164,7 @@ func TestUUIDPtr(t *testing.T) {
 				t.Fatalf("failed to get result value, got error: %v", err)
 			}
 			AssertEqual(t, valueUser, valueResult)
+			AssertEqual(t, user.UserUUID.LengthBytes(), 16)
 			AssertEqual(t, user.UserUUID.Length(), 36)
 		}
 

--- a/uuid.go
+++ b/uuid.go
@@ -8,6 +8,8 @@ import (
 	"gorm.io/gorm/schema"
 )
 
+// This datatype stores the uuid in the database as a string. To store the uuid
+// in the database as a binary (byte) array, please refer to datatypes.BinUUID.
 type UUID uuid.UUID
 
 // NewUUIDv1 generates a UUID version 1, panics on generation failure.


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [*] Do only one thing
- [*] Non breaking API changes
- [*] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

This adds a new datatype BinUUID, similar to datatypes.UUID but with a major difference being that BinUUID stores the uuid in the database as a binary (byte) array instead of a string. Developers may use either datatypes.UUID or datatypes.BinUUID as per their preference, either storing uuid in the database as a string or as a binary (byte) array respectively.

### User Case Description

<!-- Your use case -->
This new datatype is useful for developers who prefer to store uuid as binary (byte) array in the database for join performance, column size optimization or any other reasons.