### PR TITLE
Fix SQL Server dialect name to match switch case, update failing SQL Server tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,17 +131,15 @@ jobs:
 
     services:
       mssql:
-        image: mcmoe/mssqldocker:latest
+        image: mcr.microsoft.com/mssql/server:2022-latest
         env:
+          TZ: Asia/Shanghai
           ACCEPT_EULA: Y
-          SA_PASSWORD: LoremIpsum86
-          MSSQL_DB: gorm
-          MSSQL_USER: gorm
-          MSSQL_PASSWORD: LoremIpsum86
+          MSSQL_SA_PASSWORD: LoremIpsum86
         ports:
           - 9930:1433
         options: >-
-          --health-cmd="/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P LoremIpsum86 -l 30 -Q \"SELECT 1\" || exit 1"
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -N -C -l 30 -Q \"SELECT 1\" || exit 1"
           --health-start-period 10s
           --health-interval 10s
           --health-timeout 5s
@@ -163,4 +161,4 @@ jobs:
         key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('tests/go.mod') }}
 
     - name: Tests
-      run: GORM_DIALECT=sqlserver GORM_DSN="sqlserver://gorm:LoremIpsum86@localhost:9930?database=gorm" ./test_all.sh
+      run: GORM_DIALECT=sqlserver GORM_DSN="sqlserver://sa:LoremIpsum86@localhost:9930?database=master" ./test_all.sh

--- a/binuuid.go
+++ b/binuuid.go
@@ -25,6 +25,11 @@ func NewBinUUIDv4() BinUUID {
 	return BinUUID(uuid.Must(uuid.NewRandom()))
 }
 
+// NewNilBinUUID generates a nil uuid.
+func NewNilBinUUID() BinUUID {
+	return BinUUID(uuid.Nil)
+}
+
 // BinUUIDFromString returns the BinUUID representation of the specified uuidStr.
 func BinUUIDFromString(uuidStr string) BinUUID {
 	return BinUUID(uuid.MustParse(uuidStr))

--- a/binuuid_test.go
+++ b/binuuid_test.go
@@ -92,7 +92,7 @@ func TestBinUUID(t *testing.T) {
 		AssertEqual(t, user2.UserUUID.IsNil(), false)
 		AssertEqual(t, user2.UserUUID.IsEmpty(), false)
 		tx = DB.Model(&user2).Updates(
-			map[string]interface{}{"user_uuid": nil},
+			map[string]interface{}{"user_uuid": datatypes.NewNilBinUUID()},
 		)
 		AssertEqual(t, tx.Error, nil)
 		AssertEqual(t, user2.UserUUID.IsNil(), true)
@@ -171,9 +171,11 @@ func TestBinUUIDPtr(t *testing.T) {
 		user1 := users[0]
 		AssertEqual(t, user1.UserUUID.IsNilPtr(), false)
 		AssertEqual(t, user1.UserUUID.IsEmptyPtr(), false)
-		tx := DB.Model(&user1).Updates(map[string]interface{}{"user_uuid": nil})
+		tx := DB.Model(&user1).Updates(map[string]interface{}{
+			"user_uuid": datatypes.NewNilBinUUID(),
+		})
 		AssertEqual(t, tx.Error, nil)
-		AssertEqual(t, user1.UserUUID.IsNilPtr(), true)
+		AssertEqual(t, user1.UserUUID.IsNil(), true)
 		AssertEqual(t, user1.UserUUID.IsEmptyPtr(), true)
 	}
 }

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-dialects=("postgres" "postgres_simple" "mysql" "mssql" "sqlite")
+dialects=("postgres" "postgres_simple" "mysql" "sqlserver" "sqlite")
 
 for dialect in "${dialects[@]}" ; do
   if [ "$GORM_DIALECT" = "" ] || [ "$GORM_DIALECT" = "${dialect}" ]

--- a/url_test.go
+++ b/url_test.go
@@ -38,7 +38,9 @@ func TestURL(t *testing.T) {
 	DB.Create(&f2)
 
 	result := StructWithURL{}
-	if err := DB.First(&result, "file_name = ? AND storage = ?", "FLocal1",
+	if err := DB.First(
+		&result, "file_name = ? AND storage LIKE ?",
+		"FLocal1",
 		datatypes.URL{
 			Scheme: "file",
 			Path:   "/tmp/f1",
@@ -48,7 +50,9 @@ func TestURL(t *testing.T) {
 	AssertEqual(t, uf1.String(), result.Storage.String())
 
 	result = StructWithURL{}
-	if err := DB.First(&result, "file_name = ? AND storage = ?", "FRemote2",
+	if err := DB.First(
+		&result, "file_name = ? AND storage LIKE ?",
+		"FRemote2",
 		datatypes.URL{
 			Scheme:      "sftp",
 			User:        url.UserPassword("user", "pwd"),
@@ -66,7 +70,9 @@ func TestURL(t *testing.T) {
 	AssertEqual(t, us, result.Storage.String())
 
 	result = StructWithURL{}
-	if err := DB.First(&result, "file_name = ? AND storage = ?", "FRemote2",
+	if err := DB.First(
+		&result, "file_name = ? AND storage LIKE ?",
+		"FRemote2",
 		datatypes.URL{
 			Scheme:   "sftp",
 			Opaque:   "//user:pwd@127.0.0.1/f2",
@@ -78,7 +84,9 @@ func TestURL(t *testing.T) {
 	AssertEqual(t, us, result.Storage.String())
 
 	result = StructWithURL{}
-	if err := DB.First(&result, "file_name = ? AND storage = ?", "FRemote2",
+	if err := DB.First(
+		&result, "file_name = ? AND storage LIKE ?",
+		"FRemote2",
 		datatypes.URL{
 			Scheme:   "sftp",
 			User:     url.User("user"),

--- a/uuid.go
+++ b/uuid.go
@@ -35,7 +35,7 @@ func (UUID) GormDBDataType(db *gorm.DB, field *schema.Field) string {
 	case "postgres":
 		return "UUID"
 	case "sqlserver":
-		return "NVARCHAR"
+		return "NVARCHAR(128)"
 	case "sqlite":
 		return "TEXT"
 	default:


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [*] Do only one thing
- [*] Non breaking API changes
- [*] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Closes https://github.com/go-gorm/datatypes/issues/269. Also fixes failing tests for SQL Server (these seem to have never been run previously due to incorrect dialect name, for example see [this workflow](https://github.com/go-gorm/datatypes/actions/runs/10247540115/job/28346951994#step:6:3)).
 
### User Case Description

<!-- Your use case -->

Use correct dialect name when running SQL Server tests, so the tests for `sqlserver` are executed.