### PR TITLE
feature: support using path for JSON_CONTAINS

### DIFF
--- a/json.go
+++ b/json.go
@@ -451,11 +451,13 @@ func JSONArrayQuery(column string) *JSONArrayExpression {
 
 type JSONArrayExpression struct {
 	column      string
+	keys        []string
 	equalsValue interface{}
 }
 
-func (json *JSONArrayExpression) Contains(value interface{}) *JSONArrayExpression {
+func (json *JSONArrayExpression) Contains(value interface{}, keys ...string) *JSONArrayExpression {
 	json.equalsValue = value
+	json.keys = keys
 	return json
 }
 
@@ -464,9 +466,14 @@ func (json *JSONArrayExpression) Build(builder clause.Builder) {
 	if stmt, ok := builder.(*gorm.Statement); ok {
 		switch stmt.Dialector.Name() {
 		case "mysql":
-			builder.WriteString("JSON_CONTAINS (" + stmt.Quote(json.column) + ", JSON_ARRAY(")
+			builder.WriteString("JSON_CONTAINS(" + stmt.Quote(json.column) + ",JSON_ARRAY(")
 			builder.AddVar(stmt, json.equalsValue)
-			builder.WriteString("))")
+			builder.WriteByte(')')
+			if len(json.keys) > 0 {
+				builder.WriteByte(',')
+				builder.AddVar(stmt, jsonQueryJoin(json.keys))
+			}
+			builder.WriteByte(')')
 		case "sqlite":
 			builder.WriteString("exists(SELECT 1 FROM json_each(" + stmt.Quote(json.column) + ") WHERE value = ")
 			builder.AddVar(stmt, json.equalsValue)

--- a/json.go
+++ b/json.go
@@ -455,6 +455,7 @@ type JSONArrayExpression struct {
 	equalsValue interface{}
 }
 
+// Contains checks if the column[keys] has contains the value given. The keys parameter is only supported for MySQL.
 func (json *JSONArrayExpression) Contains(value interface{}, keys ...string) *JSONArrayExpression {
 	json.equalsValue = value
 	json.keys = keys

--- a/json_test.go
+++ b/json_test.go
@@ -468,11 +468,18 @@ func TestJSONArrayQuery(t *testing.T) {
 			DisplayName: "JSONArray-2",
 			Config:      datatypes.JSON("[\"c\", \"a\"]"),
 		}
+		cmp3 := Param{
+			DisplayName: "JSONArray-3",
+			Config:      datatypes.JSON("{\"test\": [\"a\", \"b\"]}"),
+		}
 
 		if err := DB.Create(&cmp1).Error; err != nil {
 			t.Errorf("Failed to create param %v", err)
 		}
 		if err := DB.Create(&cmp2).Error; err != nil {
+			t.Errorf("Failed to create param %v", err)
+		}
+		if err := DB.Create(&cmp3).Error; err != nil {
 			t.Errorf("Failed to create param %v", err)
 		}
 
@@ -496,5 +503,9 @@ func TestJSONArrayQuery(t *testing.T) {
 		}
 		AssertEqual(t, len(retMultiple), 1)
 
+		if err := DB.Where(datatypes.JSONArrayQuery("config").Contains("a", "test")).Find(&retMultiple).Error; err != nil {
+			t.Fatalf("failed to find params with json value and keys, got error %v", err)
+		}
+		AssertEqual(t, len(retMultiple), 1)
 	}
 }


### PR DESCRIPTION
### Checks
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

`JSON_CONTAINS` for MySQL supports using the `path` argument to perform the contain check deeper 
into the target column. This change adds support for the use of path in `JSONArrayExpression.Contains`
**for MySQL dialects only**.

### Use case description

<!-- Your use case -->

Previously,  `JSONArrayExpression.Contains` can only check if an array JSON column contains a specific 
value. For instance, if we have
```
| json_column |
|-------------|
| [1, 2]      |
```
We can do
```go
JSONArrayQuery("json_column").Contains(1)
```
This gets translated to
```SQL
JSON_CONTAINS(`json_column`, JSON_ARRAY(1))
```

If however, we have a nested array in this column, i.e.
```
| json_column  |
|--------------|
| {"a": [1, 2]}|
```
With the path argument, we can now do
```go
JSONArrayQuery("json_column").Contains(1, "a")
```
which gets translated to
```SQL
JSON_CONTAINS(`json_column`, JSON_ARRAY(1), "$.a")
```
