### PR TITLE
feature: support IN query clauses for nested JSON columns

### DIFF
--- a/json.go
+++ b/json.go
@@ -492,7 +492,7 @@ func (json *JSONArrayExpression) Build(builder clause.Builder) {
 				if len(json.keys) > 0 {
 					builder.WriteString("JSON_EXTRACT(")
 				}
-				builder.WriteString(stmt.Quote(json.column))
+				builder.WriteQuoted(stmt.Quote(json.column))
 				if len(json.keys) > 0 {
 					builder.WriteByte(',')
 					builder.AddVar(stmt, jsonQueryJoin(json.keys))

--- a/json.go
+++ b/json.go
@@ -490,12 +490,13 @@ func (json *JSONArrayExpression) Build(builder clause.Builder) {
 				builder.WriteByte(')')
 			case json.in:
 				if len(json.keys) > 0 {
-					builder.WriteString("JSON_EXTRACT(")
+					builder.WriteString("JSON_CONTAINS(JSON_ARRAY")
+					builder.AddVar(stmt, json.equalsValue)
+					builder.WriteString(",JSON_EXTRACT(")
 					builder.WriteQuoted(json.column)
 					builder.WriteByte(',')
 					builder.AddVar(stmt, jsonQueryJoin(json.keys))
-					builder.WriteString(") IN ")
-					stmt.AddVar(builder, json.equalsValue)
+					builder.WriteString("))")
 				}
 			}
 		case "sqlite":

--- a/json.go
+++ b/json.go
@@ -491,15 +491,12 @@ func (json *JSONArrayExpression) Build(builder clause.Builder) {
 			case json.in:
 				if len(json.keys) > 0 {
 					builder.WriteString("JSON_EXTRACT(")
-				}
-				builder.WriteQuoted(json.column)
-				if len(json.keys) > 0 {
+					builder.WriteQuoted(json.column)
 					builder.WriteByte(',')
 					builder.AddVar(stmt, jsonQueryJoin(json.keys))
-					builder.WriteByte(')')
+					builder.WriteString(") IN ")
+					stmt.AddVar(builder, json.equalsValue)
 				}
-				builder.WriteString(" IN ")
-				builder.AddVar(stmt, json.equalsValue)
 			}
 		case "sqlite":
 			switch {

--- a/json.go
+++ b/json.go
@@ -492,7 +492,7 @@ func (json *JSONArrayExpression) Build(builder clause.Builder) {
 				if len(json.keys) > 0 {
 					builder.WriteString("JSON_EXTRACT(")
 				}
-				builder.WriteQuoted(stmt.Quote(json.column))
+				builder.WriteQuoted(json.column)
 				if len(json.keys) > 0 {
 					builder.WriteByte(',')
 					builder.AddVar(stmt, jsonQueryJoin(json.keys))

--- a/json.go
+++ b/json.go
@@ -489,15 +489,19 @@ func (json *JSONArrayExpression) Build(builder clause.Builder) {
 				}
 				builder.WriteByte(')')
 			case json.in:
+				builder.WriteString("JSON_CONTAINS(JSON_ARRAY")
+				builder.AddVar(stmt, json.equalsValue)
+				builder.WriteByte(',')
 				if len(json.keys) > 0 {
-					builder.WriteString("JSON_CONTAINS(JSON_ARRAY")
-					builder.AddVar(stmt, json.equalsValue)
-					builder.WriteString(",JSON_EXTRACT(")
-					builder.WriteQuoted(json.column)
+					builder.WriteString("JSON_EXTRACT(")
+				}
+				builder.WriteQuoted(json.column)
+				if len(json.keys) > 0 {
 					builder.WriteByte(',')
 					builder.AddVar(stmt, jsonQueryJoin(json.keys))
-					builder.WriteString("))")
+					builder.WriteByte(')')
 				}
+				builder.WriteByte(')')
 			}
 		case "sqlite":
 			switch {

--- a/json_test.go
+++ b/json_test.go
@@ -463,7 +463,6 @@ func TestJSONArrayQuery(t *testing.T) {
 			DisplayName: "JSONArray-1",
 			Config:      datatypes.JSON("[\"a\", \"b\"]"),
 		}
-
 		cmp2 := Param{
 			DisplayName: "JSONArray-2",
 			Config:      datatypes.JSON("[\"c\", \"a\"]"),
@@ -471,6 +470,10 @@ func TestJSONArrayQuery(t *testing.T) {
 		cmp3 := Param{
 			DisplayName: "JSONArray-3",
 			Config:      datatypes.JSON("{\"test\": [\"a\", \"b\"]}"),
+		}
+		cmp4 := Param{
+			DisplayName: "JSONArray-4",
+			Config:      datatypes.JSON("{\"test\": \"c\"}"),
 		}
 
 		if err := DB.Create(&cmp1).Error; err != nil {
@@ -480,6 +483,9 @@ func TestJSONArrayQuery(t *testing.T) {
 			t.Errorf("Failed to create param %v", err)
 		}
 		if err := DB.Create(&cmp3).Error; err != nil {
+			t.Errorf("Failed to create param %v", err)
+		}
+		if err := DB.Create(&cmp4).Error; err != nil {
 			t.Errorf("Failed to create param %v", err)
 		}
 
@@ -504,6 +510,11 @@ func TestJSONArrayQuery(t *testing.T) {
 		AssertEqual(t, len(retMultiple), 1)
 
 		if err := DB.Where(datatypes.JSONArrayQuery("config").Contains("a", "test")).Find(&retMultiple).Error; err != nil {
+			t.Fatalf("failed to find params with json value and keys, got error %v", err)
+		}
+		AssertEqual(t, len(retMultiple), 1)
+
+		if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "d"}, "test")).Find(&retMultiple).Error; err != nil {
 			t.Fatalf("failed to find params with json value and keys, got error %v", err)
 		}
 		AssertEqual(t, len(retMultiple), 1)

--- a/json_test.go
+++ b/json_test.go
@@ -514,6 +514,11 @@ func TestJSONArrayQuery(t *testing.T) {
 		}
 		AssertEqual(t, len(retMultiple), 1)
 
+		if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "a"})).Find(&retMultiple).Error; err != nil {
+			t.Fatalf("failed to find params with json value, got error %v", err)
+		}
+		AssertEqual(t, len(retMultiple), 1)
+
 		if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "d"}, "test")).Find(&retMultiple).Error; err != nil {
 			t.Fatalf("failed to find params with json value and keys, got error %v", err)
 		}


### PR DESCRIPTION
### Checks
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Allow users to extract nested values from a JSON column and use `JSON_CONTAINS` to check if the 
extracted value belongs a referenced array. This PR implements this in MySQL (and its derived dialects only).

### Use case description

<!-- Your use case -->

Suppose we have just a JSON array column
```txt
| json_array |
|------------|
| [1, 2]     |
```

We can now do
```go
JSONArrayQuery("json_array").In([]int{1, 2})
```
which translates to
```sql
JSON_CONTAINS(JSON_ARRAY(1, 2), `json_array`)
```

Suppose we have a JSON column with a nested array as follows
```txt
| json_column |
|-------------|
| {"a": 1}    |
```

We can now do
```go
JSONArrayQuery("json_column").In([]int{1, 2}, "a")
```
which translates to
```sql
JSON_CONTAINS(JSON_ARRAY(1, 2), JSON_EXTRACT(`json_column`, '$.a'))
```

We cannot use `IN` here because [older versions of MySQL do not support comparison of JSON values 
using the `IN` operator](https://bugs.mysql.com/bug.php?id=93800).
