### PR TITLE
feature: support sqlite contains path queries

### DIFF
--- a/json.go
+++ b/json.go
@@ -506,9 +506,21 @@ func (json *JSONArrayExpression) Build(builder clause.Builder) {
 		case "sqlite":
 			switch {
 			case json.contains:
-				builder.WriteString("exists(SELECT 1 FROM json_each(" + stmt.Quote(json.column) + ") WHERE value = ")
+				builder.WriteString("EXISTS(SELECT 1 FROM json_each(")
+				builder.WriteQuoted(json.column)
+				if len(json.keys) > 0 {
+					builder.WriteByte(',')
+					builder.AddVar(stmt, jsonQueryJoin(json.keys))
+				}
+				builder.WriteString(") WHERE value = ")
 				builder.AddVar(stmt, json.equalsValue)
-				builder.WriteString(")")
+				builder.WriteString(") AND json_array_length(")
+				builder.WriteQuoted(json.column)
+				if len(json.keys) > 0 {
+					builder.WriteByte(',')
+					builder.AddVar(stmt, jsonQueryJoin(json.keys))
+				}
+				builder.WriteString(") > 0")
 			}
 		case "postgres":
 			switch {

--- a/json_test.go
+++ b/json_test.go
@@ -447,7 +447,7 @@ func TestJSONSet(t *testing.T) {
 }
 
 func TestJSONArrayQuery(t *testing.T) {
-	if SupportedDriver("mysql") {
+	if SupportedDriver("sqlite", "mysql") {
 		type Param struct {
 			ID          int
 			DisplayName string
@@ -514,14 +514,16 @@ func TestJSONArrayQuery(t *testing.T) {
 		}
 		AssertEqual(t, len(retMultiple), 1)
 
-		if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "a"})).Find(&retMultiple).Error; err != nil {
-			t.Fatalf("failed to find params with json value, got error %v", err)
-		}
-		AssertEqual(t, len(retMultiple), 1)
+		if SupportedDriver("mysql") {
+			if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "a"})).Find(&retMultiple).Error; err != nil {
+				t.Fatalf("failed to find params with json value, got error %v", err)
+			}
+			AssertEqual(t, len(retMultiple), 1)
 
-		if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "d"}, "test")).Find(&retMultiple).Error; err != nil {
-			t.Fatalf("failed to find params with json value and keys, got error %v", err)
+			if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "d"}, "test")).Find(&retMultiple).Error; err != nil {
+				t.Fatalf("failed to find params with json value and keys, got error %v", err)
+			}
+			AssertEqual(t, len(retMultiple), 1)
 		}
-		AssertEqual(t, len(retMultiple), 1)
 	}
 }


### PR DESCRIPTION
### Checks
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

Support using path for SQLite JSON array contains queries.

This addresses issue [#216](https://github.com/go-gorm/datatypes/issues/216) to some extent.

### Use case description

<!-- Your use case -->

If we have
```
| json_column   |
|---------------|
| {"a": [1, 2]} |
```
For SQLite databases, we can now do
```go
JSONArrayQuery("json_column", "a").Contains(1)
```
This gets translated to
```SQL
EXISTS(
    SELECT 1 FROM json_each(`json_column`, "$.a") WHERE value=1
) AND json_array_length(`json_column`, "$.a") > 0
```

**Note the additional `json_array_length` check compared to the previous implementation.**

This fixes the inconsistency in the behaviour between the MySQL and SQLite dialects.

Previously, if we have
```
| json_column |
|-------------|
| {"a": 1}    |
```

When we do
```go
JSONArrayQuery("json_column").Contains(1)
```
The where condition is translated to
```SQL
EXISTS(
    SELECT 1 FROM json_each(`json_column`) WHERE value=1
) 
```

This returns the row `{"a": 1}` because the `for_each` function iterates over the map as well. And
the key-value pair `"a"` and `1` fulfils the query criteria `WHERE value=1`. This behaviour is
different from the MySQL implementation.

With this change, the where condition gets translated to
```SQL
EXISTS(
    SELECT 1 FROM json_each(`json_column`) WHERE value=1
) AND json_array_length(`json_column`) > 0
```
`json_array_length` for a non-array object is 0, and therefore the second where clause is false. Additionally,
any contains query should return false for an empty target array.
