### PR TITLE
feature: implement in for sqlite databases

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -514,16 +514,14 @@ func TestJSONArrayQuery(t *testing.T) {
 		}
 		AssertEqual(t, len(retMultiple), 1)
 
-		if SupportedDriver("mysql") {
-			if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "a"})).Find(&retMultiple).Error; err != nil {
-				t.Fatalf("failed to find params with json value, got error %v", err)
-			}
-			AssertEqual(t, len(retMultiple), 1)
-
-			if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "d"}, "test")).Find(&retMultiple).Error; err != nil {
-				t.Fatalf("failed to find params with json value and keys, got error %v", err)
-			}
-			AssertEqual(t, len(retMultiple), 1)
+		if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "a"})).Find(&retMultiple).Error; err != nil {
+			t.Fatalf("failed to find params with json value, got error %v", err)
 		}
+		AssertEqual(t, len(retMultiple), 1)
+
+		if err := DB.Where(datatypes.JSONArrayQuery("config").In([]string{"c", "d"}, "test")).Find(&retMultiple).Error; err != nil {
+			t.Fatalf("failed to find params with json value and keys, got error %v", err)
+		}
+		AssertEqual(t, len(retMultiple), 1)
 	}
 }


### PR DESCRIPTION
### Checks
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

This PR ensures that the implementation for `JSONArrayQuery` in the SQLite dialect is now complete. That is,
the `In` query now works for SQLite.

### Use case description

<!-- Your use case -->

Previously, we implemented `JSONArrayQuery.In` for MySQL. Now we can do the same for SQLite. 
```txt
| id | json_column |
|----|-------------|
| 1  | [1, 2]      |
| 2  | {"a": 1}    |
```
If we wish to check if the element at key `"a"` is in the set $\\{1, 2\\}$, we can do
```go
JSONArrayQuery("json_column").In([]int{1, 2}, "a")
```
This gets translated to
```sql
CASE 
    WHEN json_type("json_column", "$.a") = 'array' 
        THEN NOT EXISTS(SELECT 1 FROM json_each("json_column", "$.a") WHERE value NOT IN (1, 2))
    ELSE json_extract("json_column", "$.a") IN (1, 2)
END
```
This query returns row 2.

The reason for differentiating arrays and other JSON objects is because MySQL's `JSON_CONTAINS` function 
is able to check if an array's elements are all within another array. If we wish to achieve feature parity for the 
different dialects, the SQLite implementation should also support such queries.

For arrays, we check if there is an element that does not exist in the target array. For other json objects, we use
`IN` directly.
