### PR TITLE
补充jsonQuery 对数组类型的查询

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gorm.io/datatypes
+module github.com/MichealJl/datatypes
 
 go 1.19
 

--- a/json.go
+++ b/json.go
@@ -305,6 +305,9 @@ const prefix = "$."
 
 func jsonQueryJoin(keys []string) string {
 	if len(keys) == 1 {
+		if keys[0] == "$" {
+			return "$"
+		}
 		return prefix + keys[0]
 	}
 


### PR DESCRIPTION
类似：
SELECT * FROM `table_name` WHERE JSON_EXTRACT(`number`,'$') LIKE '%26787-78%'

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->
