### PR TITLE
Fix: mysql JSONSet Build bool type to 1/0，expected true/false

### DIFF
--- a/json.go
+++ b/json.go
@@ -394,6 +394,8 @@ func (jsonSet *JSONSetExpression) Build(builder clause.Builder) {
 						break
 					}
 					stmt.AddVar(builder, gorm.Expr("CAST(? AS JSON)", string(b)))
+				case reflect.Bool:
+					builder.WriteString(strconv.FormatBool(rv.Bool()))
 				default:
 					stmt.AddVar(builder, value)
 				}


### PR DESCRIPTION
### 问题描述
<!--
使用 JSONSet 更新 json 结构中某个 bool 类型时，mysql 库中该值会被更新为 0/1 而不是 true/false，不符合预期地修改了我的更新内容。并且在使用 json.Unmarshal 反序列化到结构体时报错（由于类型不匹配）

-->

### User Case Description

```golang
	set := datatypes.JSONSet("object")
	set.Set("test_bool", meta.TestBool)
       db.....Update("object", set)

```

执行后结果
```
 { "test_bool": 1}

```

### 修改
bool 类型直接构造为 SQL，而不是通过 statement AddVar 替换为占位符

只进行了 mysql 的测试