### PR TITLE
should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...))

### DIFF
--- a/time.go
+++ b/time.go
@@ -60,7 +60,7 @@ func (t *Time) Scan(src interface{}) error {
 	case time.Time:
 		t.setFromTime(v)
 	default:
-		return errors.New(fmt.Sprintf("failed to scan value: %v", v))
+		return fmt.Errorf("failed to scan value: %v", v)
 	}
 
 	return nil


### PR DESCRIPTION
[rule S1028](https://staticcheck.dev/docs/checks/#S1028)

`S1028` - Simplify error construction with `fmt.Errorf`
Before:
```
errors.New(fmt.Sprintf(...))
```
After:
```
fmt.Errorf(...)
```