### PR TITLE
Use json.Number when UnmarshalJSON'ing to JSONMap

### DIFF
--- a/json_map.go
+++ b/json_map.go
@@ -63,7 +63,10 @@ func (m JSONMap) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON to deserialize []byte
 func (m *JSONMap) UnmarshalJSON(b []byte) error {
 	t := map[string]interface{}{}
-	err := json.Unmarshal(b, &t)
+	rd := bytes.NewReader(b)
+	decoder := json.NewDecoder(rd)
+	decoder.UseNumber()
+	err := decoder.Decode(&t)
 	*m = JSONMap(t)
 	return err
 }

--- a/json_map_test.go
+++ b/json_map_test.go
@@ -183,6 +183,16 @@ func TestJSONMap_Scan(t *testing.T) {
 	AssertEqual(t, obj["user_id"], 1085238870184050699)
 }
 
+func TestJSONMap_Unmarshal(t *testing.T) {
+	content := `{"user_id": 1085238870184050699, "name": "Name of user"}`
+	obj := make(datatypes.JSONMap)
+	err := obj.UnmarshalJSON([]byte(content))
+	if err != nil {
+		t.Fatalf("decode error %v", err)
+	}
+	AssertEqual(t, obj["user_id"], 1085238870184050699)
+}
+
 // TestJSONMapValueType tests the return type from JSONMap Value() method
 func TestJSONMapValueType(t *testing.T) {
 	// Test JSONMap


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [ ] Non breaking API changes
- [x] Tested

### What did this pull request do?

PR #202 made an equivalent change to .Scan() previously:

    commit 56bb801c8a4fdb3b3cda295fd2766d87834c455d
    Author: Long Le <levanlongktmt@gmail.com>
    Date:   Tue Apr 11 10:17:44 2023 +0700

        Use json.Number when scan to JSONMap (#202)

This commit makes the equivalent change to .UnmarshalJSON, so that the value is consistently correct whether it originates in the database or in a JSON object to be decoded.

This commit also adds a test validating that, which fails without this commit:

    $ go test ./...
    2025/10/23 16:06:37 testing sqlite3...
    --- FAIL: TestJSONMap_Unmarshal (0.00s)
        utils.go:40: datatypes/json_map_test.go:193: expect: 1085238870184050699, got 1085238870184050688

but passes with this commit.

### User Case Description

A `json.Unmarshal()`ed value should be of the same type as a value `Scan()`ned from the database.