### PR TITLE
Fix: Date.Value() timezone day-shift with PostgreSQL simple protocol

### DIFF
--- a/date.go
+++ b/date.go
@@ -3,26 +3,67 @@ package datatypes
 import (
 	"database/sql"
 	"database/sql/driver"
+	"fmt"
 	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
 )
 
 type Date time.Time
 
+// Scan implements sql.Scanner. Values returned from the database are always in UTC,
+// as Date.Value() stores dates as timezone-free "YYYY-MM-DD" strings.
 func (date *Date) Scan(value interface{}) (err error) {
-	nullTime := &sql.NullTime{}
-	err = nullTime.Scan(value)
-	*date = Date(nullTime.Time)
+	switch v := value.(type) {
+	case time.Time:
+		*date = Date(v)
+	case string:
+		t, err := time.ParseInLocation("2006-01-02", v, time.UTC)
+		if err != nil {
+			return err
+		}
+		*date = Date(t)
+	case []byte:
+		t, err := time.ParseInLocation("2006-01-02", string(v), time.UTC)
+		if err != nil {
+			return err
+		}
+		*date = Date(t)
+	default:
+		nullTime := &sql.NullTime{}
+		err = nullTime.Scan(value)
+		*date = Date(nullTime.Time)
+	}
 	return
 }
 
+// Value implements driver.Valuer. Returns the date as a "YYYY-MM-DD" string
+// to prevent database drivers from applying timezone conversions that shift the date.
 func (date Date) Value() (driver.Value, error) {
 	y, m, d := time.Time(date).Date()
-	return time.Date(y, m, d, 0, 0, 0, 0, time.Time(date).Location()), nil
+	return fmt.Sprintf("%04d-%02d-%02d", y, m, d), nil
 }
 
 // GormDataType gorm common data type
 func (date Date) GormDataType() string {
 	return "date"
+}
+
+// GormDBDataType gorm db data type
+func (Date) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	switch db.Dialector.Name() {
+	case "mysql":
+		return "DATE"
+	case "postgres":
+		return "DATE"
+	case "sqlserver":
+		return "DATE"
+	case "sqlite":
+		return "date"
+	default:
+		return ""
+	}
 }
 
 func (date Date) GobEncode() ([]byte, error) {

--- a/date_test.go
+++ b/date_test.go
@@ -35,7 +35,7 @@ func TestDate(t *testing.T) {
 		t.Fatalf("Failed to find record with date")
 	}
 
-	AssertEqual(t, result.Date, beginningOfDay)
+	AssertEqual(t, time.Time(result.Date).Format("2006-01-02"), beginningOfDay.Format("2006-01-02"))
 }
 
 func TestGobEncoding(t *testing.T) {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

`Date.Value()` now returns the date as a formatted string (`"YYYY-MM-DD"`) instead of `time.Time`, preventing database drivers from applying timezone conversions that shift the date by a day.

Additionally:
- `Date.Scan()` now handles `time.Time`, `string`, and `[]byte` inputs for compatibility with all database drivers. Values scanned from strings are always parsed as UTC.
- `Date.GormDBDataType()` added to return explicit column types per dialect (`DATE` for mysql/postgres/sqlserver, `date` for sqlite).
- Test updated to assert only date components (year/month/day), since `Date` is a calendar date and timezone is not part of its semantics.

### User Case Description

When using `datatypes.Date` with PostgreSQL and `PreferSimpleProtocol: true`, dates were shifted back by one day. The pgx driver's text serialization applies a UTC conversion (`UTC().Truncate(time.Microsecond)`) on `time.Time` values, which causes a day-shift for timezones ahead of UTC.

Fixes #309.