### PR TITLE
Fix: remove hard dependency on gorm.io/driver/mysql

### DIFF
--- a/json_map.go
+++ b/json_map.go
@@ -7,9 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
-
-	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
@@ -95,7 +92,7 @@ func (jm JSONMap) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
 	data, _ := jm.MarshalJSON()
 	switch db.Dialector.Name() {
 	case "mysql":
-		if v, ok := db.Dialector.(*mysql.Dialector); ok && !strings.Contains(v.ServerVersion, "MariaDB") {
+		if !isMariaDB(db.Dialector) {
 			return gorm.Expr("CAST(? AS JSON)", string(data))
 		}
 	}

--- a/json_type.go
+++ b/json_type.go
@@ -6,9 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
-
-	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
@@ -86,7 +83,7 @@ func (js JSONType[T]) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
 
 	switch db.Dialector.Name() {
 	case "mysql":
-		if v, ok := db.Dialector.(*mysql.Dialector); ok && !strings.Contains(v.ServerVersion, "MariaDB") {
+		if !isMariaDB(db.Dialector) {
 			return gorm.Expr("CAST(? AS JSON)", string(data))
 		}
 	}
@@ -147,7 +144,7 @@ func (j JSONSlice[T]) GormValue(ctx context.Context, db *gorm.DB) clause.Expr {
 
 	switch db.Dialector.Name() {
 	case "mysql":
-		if v, ok := db.Dialector.(*mysql.Dialector); ok && !strings.Contains(v.ServerVersion, "MariaDB") {
+		if !isMariaDB(db.Dialector) {
 			return gorm.Expr("CAST(? AS JSON)", string(data))
 		}
 	}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

Replace `*mysql.Dialector` type assertions with reflection-based `isMariaDB()` helper to read `ServerVersion`. Removes `gorm.io/driver/mysql` import from `json.go`, `json_map.go`, `json_type.go`.

Fixes #160

### User Case Description

Consumers of `gorm.io/datatypes` transitively pull in `gorm.io/driver/mysql` even if they only use PostgreSQL or SQLite. After this change, all driver dependencies are test-only.

Replaces #321. The original PR could not be reopened after its source fork was deleted.
